### PR TITLE
Improvements on the `compile` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,9 @@ name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -504,6 +507,7 @@ dependencies = [
  "ureq",
  "url",
  "v8",
+ "zstd",
 ]
 
 [[package]]
@@ -825,6 +829,15 @@ name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2813,3 +2826,32 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+dependencies = [
+ "cc",
+ "libc",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ dns-lookup = "1.0.8"
 mio = { version = "0.8.4", features = ["os-poll", "net"] }
 clap = { version = "3.2.19", features = ["derive"] }
 tempdir = "0.3.7"
+zstd = "0.11"
 
 [dev-dependencies]
 assert_fs = "1.0.7"

--- a/src/tools/compile.rs
+++ b/src/tools/compile.rs
@@ -16,13 +16,11 @@ pub fn run_compile(entry: &str, output: Option<String>, reload: bool) -> Result<
     let bundle = run_bundle(entry, reload, true)?;
     let bundle_size = bundle.as_bytes().len();
 
-    let dune_exe_dir = dirs::home_dir().unwrap().join(".dune/bin/");
-
-    let exe_name = "dune";
+    let exe_path = std::env::current_exe()?;
     let exe_extension = if cfg!(windows) { "exe" } else { "" };
 
     // Open dune's base binary.
-    let mut f = File::open(dune_exe_dir.join(exe_name).with_extension(exe_extension))?;
+    let mut f = File::open(exe_path)?;
     let mut buffer = Vec::new();
 
     // Read the whole binary file.


### PR DESCRIPTION
This PR changes the following:

- Compile uses the current executable (as the binary base) instead of the hard-coded `$HOME/.dune/bin` path.
- When running a standalone, command line arguments will not be parsed by clap, therefore Dune commands (`run`, `compile`, etc) will not be accessible.
- Bundles for standalone programs are now compressed/decompressed using the [zstd](https://github.com/facebook/zstd) algorithm.