### PR TITLE
Fixing important bugs and performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ Cargo.lock
 # Node.js modules
 node_modules/
 
+# VsCode configuration
+.vscode/
+
 # Custom
-/temp
-/.cache
+temp/
+.cache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dune"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -226,16 +226,9 @@ impl std::ops::DerefMut for ModuleMap {
 pub fn resolve_import(base: Option<&str>, specifier: &str) -> Result<ModulePath> {
     // Look the params and choose a loader.
     let loader: Box<dyn ModuleLoader> = {
-        // Regex to match valid URLs based on VB.NET's URL validation.
-        // http://urlregex.com/
-        lazy_static! {
-            static ref URL_REGEX: Regex =
-                Regex::new(r"(http(s)?://)?([\w-]+\.)+[\w-]+[.com]+(/[/?%&=]*)?").unwrap();
-        }
-
         let is_core_module_import = CORE_MODULES.contains_key(specifier);
-        let is_url_import =
-            URL_REGEX.is_match(specifier) || (base.is_some() && URL_REGEX.is_match(base.unwrap()));
+        let is_url_import = Url::parse(specifier).is_ok();
+        let is_url_import = is_url_import || (base.is_some() && Url::parse(base.unwrap()).is_ok());
 
         match (is_core_module_import, is_url_import) {
             (true, _) => Box::new(CoreModuleLoader),

--- a/src/tools/upgrade.rs
+++ b/src/tools/upgrade.rs
@@ -40,7 +40,6 @@ pub fn run_upgrade() -> Result<()> {
 
     // Get handles to temp and home directories.
     let temp_dir = TempDir::new("dune_zip_binary")?;
-    let dune_exe_dir = dirs::home_dir().unwrap().join(".dune/bin/");
 
     // Write binary to disk.
     fs::write(temp_dir.path().join(&archive), binary)?;
@@ -71,7 +70,7 @@ pub fn run_upgrade() -> Result<()> {
     }
 
     let next = temp_dir.path().join(exe_name).with_extension(exe_extension);
-    let current = dune_exe_dir.join(exe_name).with_extension(exe_extension);
+    let current = std::env::current_exe()?;
 
     if cfg!(windows) {
         // On windows you cannot replace the currently running executable.


### PR DESCRIPTION
Changes with this PR:

- Loader's URL regex validator replaced by just using the `URL` crate.
- Upgrade command gets the binary location from the current executable (env variable) rather than `$HOME/.dune/...`.
- Dune's event-loop is no longer a busy loop (major bug fixed). 🎉