### PR TITLE
Fixing timers issue when idling on poll-phase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dune"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dune"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Alex Alikiotis <alexalikiotis5@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dune",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A hobby runtime for JavaScript and TypeScript 🚀",
   "main": "src/js/main.js",
   "scripts": {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -44,7 +44,7 @@ pub struct JsRuntimeState {
     pub modules: ModuleMap,
     /// A handle to the runtime's event-loop.
     pub handle: LoopHandle,
-    /// A handle to the event-loop that can interrupt the poll (wait) phase.
+    /// A handle to the event-loop that can interrupt the poll-phase.
     pub interrupt_handle: LoopInterruptHandle,
     /// Holds JS pending futures scheduled by the event-loop.
     pub pending_futures: Vec<Box<dyn JsFuture>>,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,6 +4,7 @@ use crate::errors::unwrap_or_exit;
 use crate::errors::JsError;
 use crate::event_loop::EventLoop;
 use crate::event_loop::LoopHandle;
+use crate::event_loop::LoopInterruptHandle;
 use crate::event_loop::TaskResult;
 use crate::hooks::host_import_module_dynamically_cb;
 use crate::hooks::host_initialize_import_meta_object_cb;
@@ -43,6 +44,8 @@ pub struct JsRuntimeState {
     pub modules: ModuleMap,
     /// A handle to the runtime's event-loop.
     pub handle: LoopHandle,
+    /// A handle to the event-loop that can interrupt the poll (wait) phase.
+    pub interrupt_handle: LoopInterruptHandle,
     /// Holds JS pending futures scheduled by the event-loop.
     pub pending_futures: Vec<Box<dyn JsFuture>>,
     /// Indicates the start time of the process.
@@ -139,6 +142,7 @@ impl JsRuntime {
             context,
             modules: ModuleMap::default(),
             handle: event_loop.handle(),
+            interrupt_handle: event_loop.interrupt_handle(),
             pending_futures: Vec::new(),
             startup_moment: Instant::now(),
             time_origin,

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -87,6 +87,14 @@ fn create_timeout(
                 params: Rc::clone(&params),
             };
             state.pending_futures.push(Box::new(future));
+
+            // Important: For non-repeatable timers we have to send an interrupt
+            // signal to the event-loop to prevent the scenario when the even-loop
+            // will idle in the poll phase waiting for I/O while the timer's JS future
+            // is pending in the runtime level.
+            if !repeatable {
+                state.interrupt_handle.interrupt();
+            }
         }
     };
 


### PR DESCRIPTION
This PR fixes a critical bug on timers not be able to run under circumstances when the poll phase idles.