### PR TITLE
Adding `createReadStream()` and `createWriteStream()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ For more examples look at the <a href="./examples">examples</a> directory.
 > This module should also include a `Sync` method for every async operation available.
 
 - [x] `copyFile(src, dest)`: Copies `src` to `dest`.
-- [ ] `createReadStream(path, options?)`: Creates a readable IO stream. 🚧
-- [ ] `createWriteStream(path, options?)`: Creates a writable IO stream. 🚧
+- [x] `createReadStream(path, options?)`: Returns a new readable IO stream.
+- [x] `createWriteStream(path, options?)`: Returns a new writable IO stream.
 - [x] `open(path, mode?)`: Asynchronous file open.
 - [x] `mkdir(path, options?)`: Creates a directory.
 - [x] `readFile(path, options?)`: Reads the entire contents of a file.
@@ -194,7 +194,7 @@ For more examples look at the <a href="./examples">examples</a> directory.
 
 ### Stream
 
-> Streams are very different from Node.js and are based on [async-generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGeneratorFunction).
+> Streams are very different from Node.js and are based on [async-generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator).
 
 - [x] `pipe(source, ...targets)`: An alias of `pipeline()`.
 - [x] `pipeline(source, ...targets)`: Pipes between streams while forwarding errors.

--- a/examples/tcpClient.js
+++ b/examples/tcpClient.js
@@ -18,7 +18,7 @@ client.on('data', (data) => console.log(data));
 
 client.on('close', () => console.log('Connection closed.'));
 
-// 2. Using async iterators to handle data
+// 2. Using async iterators to handle data.
 
 const client2 = new net.Socket();
 

--- a/examples/tcpStream.js
+++ b/examples/tcpStream.js
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import net from 'net';
+import { pipeline } from 'stream';
+import shortid from 'https://cdn.skypack.dev/shortid';
+
+const server = net.createServer((socket) => {
+  const id = shortid();
+  const writer = fs.createWriteStream(`${process.cwd()}/${id}.txt`);
+  pipeline(socket, writer);
+});
+
+await server.listen(3000, '127.0.0.1');
+
+console.log('Server listening on port 3000...');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -56,6 +56,7 @@ Object.defineProperty(process, 'stdout', {
   get() {
     return {
       write: process.binding('stdio').write,
+      end() {},
     };
   },
   configurable: true,

--- a/src/js/net.js
+++ b/src/js/net.js
@@ -300,6 +300,7 @@ export class Socket extends EventEmitter {
 
     // Check if the remote host closed the connection.
     if (arrayBufferView.byteLength === 0) {
+      this._asyncDispatch(null);
       this.emit('end');
       this.destroy();
       return;
@@ -339,6 +340,7 @@ export class Socket extends EventEmitter {
   async *[Symbol.asyncIterator]() {
     let data;
     while ((data = await this.read())) {
+      if (!data) break;
       yield data;
     }
   }


### PR DESCRIPTION
This PR:
- Implements the `.createReadStream()` and `createWriteStream()` methods.
- Fixes a bug with net sockets and async-iterators.
- Makes the `process.stdout` a writable stream.
- Adds additional examples.