### PR TITLE
Fixing ANSI colors issue on windows platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,7 @@ dependencies = [
  "dirs 4.0.0",
  "dns-lookup",
  "downcast-rs",
+ "enable-ansi-support",
  "lazy_static",
  "mio",
  "nanoid",
@@ -491,6 +492,15 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "enable-ansi-support"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4ff3ae2a9aa54bf7ee0983e59303224de742818c1822d89f07da9856d9bc60"
+dependencies = [
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ name = "dune"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26.1", features=["signal"] }
 
+[target.'cfg(windows)'.dependencies]
+enable-ansi-support = "0.2.1"
+
 [dependencies]
 v8 = { version = "0.58.0", default-features = false }
 clap = "4.0.27"

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,12 @@ fn main() {
         setup_panic_hook();
     }
 
+    #[cfg(target_family = "windows")]
+    {
+        // In shitty platforms like Windows we have to manually enable ANSI colors. ¯\_(ツ)_/¯
+        let _ = enable_ansi_support::enable_ansi_support();
+    }
+
     // Try run dune as a compiled standalone program.
     match compile::extract_standalone() {
         Ok(Some(source)) => run_standalone(source),


### PR DESCRIPTION
This PR:
- Fixes colors issue on the Windows platform by enabling ANSI support on start-up.