### PR TITLE
Adding option to disable core module resolution

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -29,7 +29,12 @@ pub fn module_resolve_cb<'a>(
     let dependant = state.module_map.get_path(referrer);
 
     let specifier = specifier.to_rust_string_lossy(scope);
-    let specifier = unwrap_or_exit(resolve_import(dependant.as_deref(), &specifier, import_map));
+    let specifier = unwrap_or_exit(resolve_import(
+        dependant.as_deref(),
+        &specifier,
+        false,
+        import_map,
+    ));
 
     // This call should always give us back the module.
     let module = state.module_map.get(&specifier).unwrap();
@@ -89,7 +94,7 @@ fn import_meta_resolve(
     let specifier = args.get(0).to_rust_string_lossy(scope);
     let import_map = JsRuntime::state(scope).borrow().options.import_map.clone();
 
-    match resolve_import(Some(&base), &specifier, import_map) {
+    match resolve_import(Some(&base), &specifier, false, import_map) {
         Ok(path) => rv.set(v8::String::new(scope, &path).unwrap().into()),
         Err(e) => throw_type_error(scope, &e.to_string()),
     };
@@ -152,7 +157,7 @@ pub fn host_import_module_dynamically_cb<'s>(
 
     let import_map = state.options.import_map.clone();
 
-    let specifier = match resolve_import(Some(&base), &specifier, import_map) {
+    let specifier = match resolve_import(Some(&base), &specifier, false, import_map) {
         Ok(specifier) => specifier,
         Err(e) => {
             let exception = v8::String::new(scope, &e.to_string()[18..]).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,8 +63,8 @@ fn run_command(mut args: ArgMatches) {
     // to an absolute path. If the first time fails we will append `./` to
     // it first, and retry the resolution in case the user forgot to specify it.
     let filename = unwrap_or_exit(
-        resolve_import(None, &script, import_map.clone())
-            .or_else(|_| resolve_import(None, &format!("./{script}"), import_map.clone())),
+        resolve_import(None, &script, true, import_map.clone())
+            .or_else(|_| resolve_import(None, &format!("./{script}"), true, import_map.clone())),
     );
 
     // Check if we have to run on `watch` mode.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -256,7 +256,7 @@ impl JsRuntime {
         // location passed as parameter as an ES module.
         let path = match source.is_some() {
             true => filename.to_string(),
-            false => unwrap_or_exit(resolve_import(None, filename, None)),
+            false => unwrap_or_exit(resolve_import(None, filename, false, None)),
         };
 
         // Create static import module graph.

--- a/src/tools/bundle.rs
+++ b/src/tools/bundle.rs
@@ -166,6 +166,7 @@ impl<'a> Resolve for Resolver<'a> {
             Path::new(&resolve_import(
                 base,
                 specifier,
+                true,
                 self.options.import_map.clone(),
             )?)
             .to_path_buf(),
@@ -183,7 +184,7 @@ impl swc_bundler::Hook for Hook {
     ) -> Result<Vec<KeyValueProp>, Error> {
         // Get filename as string.
         let file_name = module.file_name.to_string();
-        let file_name = resolve_import(None, &file_name, None)?;
+        let file_name = resolve_import(None, &file_name, true, None)?;
 
         // Compute .main and .url properties.
         Ok(vec![


### PR DESCRIPTION
This PR fixes the following problem:

```sh
$ dune run console
```

Currently this runs cause the module resolution algorithm always takes into account the available core modules.

Expected behaviour:

```
Error: Module not found "/Users/<USER>/Projects/github.com/aalykiot/dune/console.js"
```