### PR TITLE
Adding automatic release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A hobby runtime for JavaScript and TypeScript 🚀",
   "main": "src/js/main.js",
   "scripts": {
+    "build:aarch64": "./scripts/build-aarch64.sh",
     "lint": "eslint ./src/js/**/*.js"
   },
   "repository": {
@@ -11,7 +12,7 @@
     "url": "git+https://github.com/aalykiot/dune.git"
   },
   "keywords": [],
-  "author": "",
+  "author": "Alex Alikiotis <alexalikiotis5@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/aalykiot/dune/issues"

--- a/scripts/build-aarch64.sh
+++ b/scripts/build-aarch64.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Check if zip is installed.
+if ! command -v zip >/dev/null; then
+  echo "Error: zip is required to build Dune." 1>&2
+  echo "=>> You can install zip via \"brew install zip\" on MacOS or \"apt-get install zip -y\" on Linux." 1>&2
+  exit 1
+fi
+
+# Set the output directory to cwd if no argument is provided.
+output=${1:-$(pwd)}
+
+# Build binary for aarch64-apple-darwin.
+cargo build --release --target=aarch64-apple-darwin
+
+# Create release zip bundle.
+mv ./target/aarch64-apple-darwin/release/dune .
+
+zip -r dune-aarch64-apple-darwin.zip dune README.md LICENSE.md
+
+rm dune
+
+# Move zip to specified output destination.
+if [[ $output != $PWD ]]; then
+  mv dune-aarch64-apple-darwin.zip $output
+fi


### PR DESCRIPTION
Since GitHub actions [still don't have](https://github.com/github/roadmap/issues/528) aarch64-macos runners available this script automates a bit the build+release process for this target.