### PR TITLE
Accepting non-standard CLI arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -297,6 +297,7 @@ fn main() {
             Command::new("run")
                 .about("Run a JavaScript or TypeScript program")
                 .arg_required_else_help(true)
+                .allow_external_subcommands(true)
                 .arg(arg!(<SCRIPT> "The script that will run").required(true))
                 .arg(arg!(-r --reload "Reload every URL import (cache is ignored)"))
                 .arg(arg!(--seed <NUMBER> "Make the Math.random() method predictable"))


### PR DESCRIPTION
A bug was found that didn't allow non-standard CLI arguments passed into the JS land.

e.x `dune run main.js -- --foo` didn't work.