### PR TITLE
Adding support for WASM imports

### DIFF
--- a/src/transpilers.rs
+++ b/src/transpilers.rs
@@ -176,3 +176,20 @@ impl Jsx {
         Ok(String::from_utf8_lossy(&buffer).to_string())
     }
 }
+
+pub struct Wasm;
+
+impl Wasm {
+    // Converts a wasm binary into an ES module template.
+    pub fn parse(source: &str) -> String {
+        format!(
+            "
+        const wasmCode = new Uint8Array({:?});
+        const wasmModule = new WebAssembly.Module(wasmCode);
+        const wasmInstance = new WebAssembly.Instance(wasmModule);
+        export default wasmInstance.exports;
+        ",
+            source.as_bytes()
+        )
+    }
+}


### PR DESCRIPTION
This PR allows to directly import wasm binaries from JavaScript.

```js
import wasm from './add.wasm';
```

> WASM module is exported as a default export