### PR TITLE
Fixing race condition bug on dynamic imports

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -6,6 +6,7 @@ use crate::modules::load_import;
 use crate::modules::resolve_import;
 use crate::modules::EsModuleFuture;
 use crate::modules::ModuleGraph;
+use crate::modules::ModuleStatus;
 use crate::runtime::JsRuntime;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -205,9 +206,10 @@ pub fn host_import_module_dynamically_cb<'s>(
 
     let graph = ModuleGraph::dynamic_import(&specifier, global_promise);
     let graph_rc = Rc::new(RefCell::new(graph));
+    let status = ModuleStatus::Fetching;
 
     state.module_map.pending.push(Rc::clone(&graph_rc));
-    state.module_map.seen.insert(specifier.clone());
+    state.module_map.seen.insert(specifier.clone(), status);
 
     /*  Use the event-loop to asynchronously load the requested module. */
 

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -133,7 +133,7 @@ pub enum ImportKind {
     Dynamic(v8::Global<v8::PromiseResolver>),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModuleStatus {
     // Indicates the module is being fetched.
     Fetching,


### PR DESCRIPTION
Fixes a bug that causes Dune to panic randomly (hence race condition) when multiple module graphs require the same import but the module status is not tracked correctly.

```js
// base.js
console.log('Hello, world!');

// foo1.js
import './base';

// foo2.js
import './base';

// main.js
await Promise.all([import('./foo1'), import('./foo2')]);
```