### PR TITLE
Updating rusty_v8 to version 0.77.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dune"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2592,9 +2592,9 @@ checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "v8"
-version = "0.76.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4e8ae7ef8b4e852e728e343cb6bb471a0424dfefa22585ea0c14a61252d73f"
+checksum = "d2c1cc5961099892fa7a60b2486cf07065c6006118bc34ae12ef18f36d0d2489"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dune"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Alex Alikiotis <alexalikiotis5@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -20,7 +20,7 @@ nix = { version = "0.27.0", features = ["signal"] }
 enable-ansi-support = "0.2.1"
 
 [dependencies]
-v8 = { version = "0.76.0", default-features = false }
+v8 = { version = "0.77.0", default-features = false }
 clap = "4.0.27"
 anyhow = "1.0.52"
 colored = "2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dune",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A hobby runtime for JavaScript and TypeScript 🚀",
   "main": "src/js/main.js",
   "scripts": {


### PR DESCRIPTION
This PR will also fix the compilation issues on **aarch64** target.