### PR TITLE
Fixing panics on TypeScript compilations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dune"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -781,6 +781,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "hstr"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de90d3db62411eb62eddabe402d706ac4970f7ac8d088c05f11069cad9be9857"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "phf 0.11.2",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -1833,9 +1846,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "smartstring"
@@ -1881,12 +1894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "stacker"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,18 +1933,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "string_cache_codegen"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
-dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "string_enum"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,23 +1953,21 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swc_atoms"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf7a12229f0c0efb654a6a0f8cbfd94fbd320a57c764857a82d8abe9342b450"
+checksum = "b8a9e1b6d97f27b6abe5571f8fe3bdbd2fa987299fc2126450c7cde6214896ef"
 dependencies = [
+ "hstr",
  "once_cell",
  "rustc-hash",
  "serde",
- "string_cache",
- "string_cache_codegen",
- "triomphe",
 ]
 
 [[package]]
 name = "swc_bundler"
-version = "0.222.17"
+version = "0.222.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d53f076e172c4d83bb408b56ba09b270bc067ecbbacbc8819fad2e3c969443"
+checksum = "8401b3eb070f535d47c33858d2c49b921940d4161b1dc59b771586531edf9304"
 dependencies = [
  "anyhow",
  "crc",
@@ -2002,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.33.2"
+version = "0.33.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290470b7a9a4323c356208caf3c6c424b4c68e1d9aa63758b21d3e04e89cb07"
+checksum = "49fba1ce1d44f142b9e8212a6360fc7818e2c99c7f5ebe8b4fa4061c5764e48e"
 dependencies = [
  "ast_node",
  "atty",
@@ -2055,13 +2048,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.110.2"
+version = "0.110.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2505e1bb74456695f6a92e68005a5fd1054fb3516e88268e81dbcfa4b26394b4"
+checksum = "4cefcc1c71bf00e48da7b65801d1fccf7eed2b7fa1fc5c4848ed09801bfe2403"
 dependencies = [
  "bitflags 2.4.0",
  "is-macro",
  "num-bigint",
+ "phf 0.11.2",
  "scoped-tls",
  "string_enum",
  "swc_atoms",
@@ -2071,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.146.5"
+version = "0.146.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a0acb97f29718a45b26955d3f27098dc656552ca01e9efdd2197faa0d14f94"
+checksum = "4105aa856cf108c883d484e5f252bca16832f0a50c2b331a8326a86d5500474b"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -2103,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.45.3"
+version = "0.45.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ba1d17621b46879f87dfddc919f7fd8e65993e73f9ea38315feae9bd53a4e3"
+checksum = "cc83806e30310943718eef1209c388f375417bcc3e499df8820c189d92ecf05f"
 dependencies = [
  "anyhow",
  "pathdiff",
@@ -2116,13 +2110,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.141.5"
+version = "0.141.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b5f31caca7daa4e9737f6073de461fa078aa36175afe5431966b92882e56f9"
+checksum = "acfad502c2e0579e09e216da1c627d583fdbc6c8a08f2c8bd0160f9119d4246d"
 dependencies = [
  "either",
+ "new_debug_unreachable",
  "num-bigint",
  "num-traits",
+ "phf 0.11.2",
  "serde",
  "smallvec",
  "smartstring",
@@ -2136,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.134.10"
+version = "0.134.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18150ea5c817b8f2f13c06fd99229d82754efc5c32e07dbf9745a33dc8d8232e"
+checksum = "6b008a854b2429e01b5c810e415392fe18560fc868997d0cbd8587a6d8c37206"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -2172,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.195.11"
+version = "0.195.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f41ba9a60a15791db0f7d1311c8d02f443404f88de56456a92914425b96723c"
+checksum = "ec62f44ddacecf926214682efa7ad8aa942b1654de1ebc7497c454effe8f76f6"
 dependencies = [
  "dashmap",
  "indexmap 1.9.3",
@@ -2196,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.180.14"
+version = "0.180.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3e494991946a57e253ff94d35655cd1d1218dd4075926c671b3ab0eacd10fe"
+checksum = "6dac44af882b337afd9dabba1d949702c589157b338d686674a8758310225226"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -2220,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.185.10"
+version = "0.185.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb9a42b5d0317bb6c314c924a024636bd1e6f4cd2c24b8478bfb336426ddbcc"
+checksum = "4a3d8caab9443347bc408366c9b50d3fe685880bd92cffa852b8005a0539af38"
 dependencies = [
  "ryu-js",
  "serde",
@@ -2237,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.124.9"
+version = "0.124.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d86cb80fb98018eba38720f940cf6c70df873d17092c0e4e390ddd4c01557a2"
+checksum = "d32413e3fe1aa7a375d8c57fad7321d51b8b8a7b30b403fe468a74ccfc8b71a5"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -2255,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.96.2"
+version = "0.96.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98eae0217e246aff1fc010bf716a94b781effa223b0e39449dced60db012deb"
+checksum = "21305b130986e771206c9f447c8040f9b3be47c9fbbb1f659904e223b8e1c007"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2281,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.21.2"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbabf18473ea14f374cf6fb46737e5ad61bc5dbea1f50fa3bf506c79b2e11d2"
+checksum = "392047ce047ab6f9c02ef17e7e19627c0050fe6dbb0bccd2350a92664a859c62"
 dependencies = [
  "indexmap 1.9.3",
  "petgraph",
@@ -2293,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.22.2"
+version = "0.22.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c8b0d5902effce3c816362cb7ff0b3aad65246e84e56493b06afc6e42d42ee"
+checksum = "ebb1843242b0ee38517116da75576e13bcdcc8e08af288537e8745d480c31cfc"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -2491,16 +2487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "triomphe"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee8098afad3fb0c54a9007aab6804558410503ad676d4633f9c2559a00ac0f"
-dependencies = [
- "serde",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,9 +2585,9 @@ checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "v8"
-version = "0.80.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "959eead7f97b80b08ec7154262c3abef0d9c4de2f4b80c100762d7fa880258fe"
+checksum = "b75f5f378b9b54aff3b10da8170d26af4cfd217f644cf671badcd13af5db4beb"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dune"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Alex Alikiotis <alexalikiotis5@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -20,7 +20,7 @@ nix = { version = "0.27.0", features = ["signal"] }
 enable-ansi-support = "0.2.1"
 
 [dependencies]
-v8 = { version = "0.80.0", default-features = false }
+v8 = { version = "0.81.0", default-features = false }
 clap = "4.0.27"
 anyhow = "1.0.52"
 colored = "2.0.0"
@@ -40,16 +40,16 @@ url = "2.2.2"
 clearscreen = "2.0.0"
 bincode = "1.3.3"
 downcast-rs = { version = "1.2.0", default-features = false }
-swc_common = { version = "0.33.2", features = ["tty-emitter"] }
-swc_ecma_codegen = "0.146.5"
-swc_ecma_parser = "0.141.5"
-swc_ecma_transforms_base = "0.134.10"
-swc_ecma_transforms_typescript = "0.185.10"
-swc_ecma_transforms_react = "0.180.14"
-swc_ecma_visit = "0.96.2"
-swc_bundler = "0.222.17"
-swc_ecma_ast = "0.110.2"
-swc_atoms = "0.6.0"
+swc_common = { version = "0.33.8", features = ["tty-emitter"] }
+swc_ecma_codegen = "0.146.25"
+swc_ecma_parser = "0.141.22"
+swc_ecma_transforms_base = "0.134.31"
+swc_ecma_transforms_typescript = "0.185.38"
+swc_ecma_transforms_react = "0.180.40"
+swc_ecma_visit = "0.96.9"
+swc_bundler = "0.222.43"
+swc_ecma_ast = "0.110.9"
+swc_atoms = "0.6.4"
 serde = { version = "1.0.142", features = ["derive"] }
 serde_json = "1.0.88"
 dns-lookup = "2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dune",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A hobby runtime for JavaScript and TypeScript 🚀",
   "main": "src/js/main.js",
   "scripts": {

--- a/src/transpilers.rs
+++ b/src/transpilers.rs
@@ -61,8 +61,8 @@ impl TypeScript {
 
         let mut parser = Parser::new_from(lexer);
 
-        let module = match parser
-            .parse_module()
+        let program = match parser
+            .parse_program()
             .map_err(|e| e.into_diagnostic(&handler).emit())
         {
             Ok(module) => module,
@@ -74,7 +74,7 @@ impl TypeScript {
 
         GLOBALS.set(&globals, || {
             // Apply the rest SWC transforms to generated code.
-            let module = module
+            let program = program
                 .fold_with(&mut resolver(Mark::new(), Mark::new(), true))
                 .fold_with(&mut strip(Mark::new()))
                 .fold_with(&mut hygiene())
@@ -88,7 +88,7 @@ impl TypeScript {
                     wr: JsWriter::new(cm, "\n", &mut buffer, None),
                 };
 
-                emitter.emit_module(&module).unwrap();
+                emitter.emit_program(&program).unwrap();
             }
         });
 


### PR DESCRIPTION
This PR:
- Fixes runtime panics on TypeScript compilations
- Upgrades V8 to 0.81.0
- Upgrades all the SWC crates