### PR TITLE
Adding support for creating HTTP servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dune"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dune"
-version = "0.4.6"
+version = "0.5.0"
 authors = ["Alex Alikiotis <alexalikiotis5@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `process`: An object that provides info about the current dune process.
 - [x] `structuredClone`: Creates a deep clone of a given value.
 - [x] `AbortController` / `AbortSignal`: Allows you to communicate with a request and abort it.
-- [x] `fetch`: A wrapper around `http.request` (not compatible with WHATWG fetch).
+- [x] `fetch`: A wrapper around `http.request` (not fully compatible with WHATWG fetch).
 
 ### Module Metadata
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `process`: An object that provides info about the current dune process.
 - [x] `structuredClone`: Creates a deep clone of a given value.
 - [x] `AbortController` / `AbortSignal`: Allows you to communicate with a request and abort it.
+- [ ] `fetch`: A wrapper around `http.request` (not compatible with WHATWG fetch).
 
 ### Module Metadata
 
@@ -117,7 +118,7 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `cwd()`: Current working directory.
 - [x] `env`: An object containing the user environment.
 - [x] `exit(code?)`: Exits the program with the given code.
-- [ ] `getActiveResourcesInfo()`: An array of strings containing the types of the active resources that are currently keeping the event loop alive.
+- [ ] `getActiveResourcesInfo()`: An array of strings containing the types of the active resources that are currently keeping the event loop alive. 🚧
 - [x] `memoryUsage()`: An object describing the memory usage.
 - [x] `nextTick(cb, ...args?)`: Adds callback to the "next tick queue".
 - [x] `pid`: PID of the process.
@@ -165,9 +166,9 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `createConnection(options)`: Creates unix socket connection to a remote host.
 - [x] `TimeoutError`: Custom error signalling a socket (read) timeout.
 
-### Net.Server
+#### `net.Server`
 
-> Net.Server is a class extending `EventEmitter` and implements `@@asyncIterator`.
+> net.Server is a class extending `EventEmitter` and implements `@@asyncIterator`.
 
 - [x] `listen(port, host?)`: Begin accepting connections on the specified port and host.
 - [x] `accept()`: Waits for a TCP client to connect and accepts the connection.
@@ -178,9 +179,9 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `Event: 'close'`: Emitted when the server stops accepting new connections.
 - [x] `Event: 'error'`: Emitted when an error occurs.
 
-### Net.Socket
+#### `net.Socket`
 
-> Net.Socket is a class extending `EventEmitter` and implements `@@asyncIterator`.
+> net.Socket is a class extending `EventEmitter` and implements `@@asyncIterator`.
 
 - [x] `connect(options)`: Opens the connection for a given socket.
 - [x] `setEncoding(encoding)`: Sets the encoding for the socket.
@@ -234,6 +235,44 @@ Body Mixins
 - [x] `text()`: Produces a UTF-8 string representation of the body.
 - [x] `json()`: Formats the body using JSON parsing.
 </details>
+
+#### `http.Server`
+
+> http.Server is a class extending `EventEmitter` and implements `@@asyncIterator`.
+
+- [ ] `listen(port, host?)` - Starts the HTTP server listening for connections.
+- [ ] `close()` - Stops the server from accepting new connections.
+- [ ] `Event: 'request'` - Emitted each time there is a request.
+- [ ] `Event: 'close'` - Emitted when the server closes.
+- [ ] `Event: 'clientError'` - Emitted when a client connection emits an 'error' event.
+
+#### `http.ServerRequest`
+
+> http.ServerRequest implements `@@asyncIterator`.
+
+- [ ] `headers` - The request headers object.
+- [ ] `httpVersion` - The HTTP version sent by the client.
+- [ ] `method` - The request method as a string.
+- [ ] `url` - Request URL string.
+- [ ] `text()`: Produces a UTF-8 string representation of the body.
+- [ ] `json()`: Formats the body using JSON parsing.
+
+#### `http.ServerResponse`
+
+> http.ServerResponse implements `stream.Writable`.
+
+- [ ] `write(data)`: This sends a chunk of the response body.
+- [ ] `end(data?)`: Signals that all of the response headers and body have been sent.
+- [ ] `writeHead(code, message?, headers?)`: Sends a response header to the request.
+- [ ] `setHeader(name, value)`: Sets a single header value for implicit headers.
+- [ ] `getHeader(name)`: Reads out a header that's already been queued but not sent to the client.
+- [ ] `getHeaderNames()`: Returns an array containing the unique names of the current outgoing headers.
+- [ ] `getHeaders()`: Returns a copy of the current outgoing headers.
+- [ ] `hasHeader(name)`: Returns true if the header identified is currently set.
+- [ ] `removeHeader(name)`: Removes a header that's queued for implicit sending.
+- [ ] `headersSent`: Boolean (read-only). True if headers were sent, false otherwise.
+- [ ] `socket`: Reference to the underlying socket.
+- [ ] `Event: 'finish'`: Emitted when the (full) response has been sent.
 
 ### Stream
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For more examples look at the <a href="./examples">examples</a> directory.
 
 ### Net
 
-- [x] `createServer(connectionListener?)`: Creates a new TCP server.
+- [x] `createServer(connectionHandler?)`: Creates a new TCP server.
 - [x] `createConnection(options)`: Creates unix socket connection to a remote host.
 - [x] `TimeoutError`: Custom error signalling a socket (read) timeout.
 
@@ -209,7 +209,7 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `METHODS`: A list of the HTTP methods that are supported by the parser.
 - [x] `STATUS_CODES`: A collection of all the standard HTTP response status codes.
 - [x] `request(url, options?)`: Performs an HTTP request.
-- [ ] `createServer(requestListener?)`: Creates a new HTTP server.
+- [x] `createServer(requestHandler?)`: Creates a new HTTP server.
 
 <details><summary>Details</summary>
 <p></p>
@@ -265,10 +265,10 @@ Body Mixins
 
 - [x] `write(data)`: This sends a chunk of the response body.
 - [x] `end(data?)`: Signals that all of the response headers and body have been sent.
-- [x] `writeHead(code, message?, headers?)`: Sends a response header to the request.
+- [x] `writeHead(code, message?, headers?)`: Sends the response headers to the client.
 - [x] `setHeader(name, value)`: Sets a single header value for implicit headers.
 - [x] `getHeader(name)`: Reads out a header that's already been queued but not sent to the client.
-- [x] `getHeaderNames()`: Returns an array containing the unique names of the current outgoing headers.
+- [ ] `getHeaderNames()`: Returns an array containing the unique names of the current outgoing headers.
 - [x] `getHeaders()`: Returns a copy of the current outgoing headers.
 - [x] `hasHeader(name)`: Returns true if the header identified is currently set.
 - [x] `removeHeader(name)`: Removes a header that's queued for implicit sending.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ const server = net.createServer(async (socket) => {
   await socket.destroy();
 });
 
-console.log('Server is listening on port 3000...');
-
 await server.listen(3000, '127.0.0.1');
+
+console.log('Server is listening on port 3000...');
 ```
 
 JSX/TSX files are also supported for server side rendering.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `METHODS`: A list of the HTTP methods that are supported by the parser.
 - [x] `STATUS_CODES`: A collection of all the standard HTTP response status codes.
 - [x] `request(url, options?)`: Performs an HTTP request.
+- [ ] `createServer(requestListener?)`: Creates a new HTTP server.
 
 <details><summary>Details</summary>
 <p></p>
@@ -250,29 +251,29 @@ Body Mixins
 
 > http.ServerRequest implements `@@asyncIterator`.
 
-- [ ] `headers` - The request headers object.
-- [ ] `httpVersion` - The HTTP version sent by the client.
-- [ ] `method` - The request method as a string.
-- [ ] `url` - Request URL string.
-- [ ] `text()`: Produces a UTF-8 string representation of the body.
-- [ ] `json()`: Formats the body using JSON parsing.
+- [x] `headers` - The request headers object.
+- [x] `httpVersion` - The HTTP version sent by the client.
+- [x] `method` - The request method as a string.
+- [x] `url` - Request URL string.
+- [x] `text()`: Produces a UTF-8 string representation of the body.
+- [x] `json()`: Formats the body using JSON parsing.
 
 #### `http.ServerResponse`
 
 > http.ServerResponse implements `stream.Writable`.
 
-- [ ] `write(data)`: This sends a chunk of the response body.
-- [ ] `end(data?)`: Signals that all of the response headers and body have been sent.
-- [ ] `writeHead(code, message?, headers?)`: Sends a response header to the request.
-- [ ] `setHeader(name, value)`: Sets a single header value for implicit headers.
-- [ ] `getHeader(name)`: Reads out a header that's already been queued but not sent to the client.
-- [ ] `getHeaderNames()`: Returns an array containing the unique names of the current outgoing headers.
-- [ ] `getHeaders()`: Returns a copy of the current outgoing headers.
-- [ ] `hasHeader(name)`: Returns true if the header identified is currently set.
-- [ ] `removeHeader(name)`: Removes a header that's queued for implicit sending.
-- [ ] `headersSent`: Boolean (read-only). True if headers were sent, false otherwise.
-- [ ] `socket`: Reference to the underlying socket.
-- [ ] `Event: 'finish'`: Emitted when the (full) response has been sent.
+- [x] `write(data)`: This sends a chunk of the response body.
+- [x] `end(data?)`: Signals that all of the response headers and body have been sent.
+- [x] `writeHead(code, message?, headers?)`: Sends a response header to the request.
+- [x] `setHeader(name, value)`: Sets a single header value for implicit headers.
+- [x] `getHeader(name)`: Reads out a header that's already been queued but not sent to the client.
+- [x] `getHeaderNames()`: Returns an array containing the unique names of the current outgoing headers.
+- [x] `getHeaders()`: Returns a copy of the current outgoing headers.
+- [x] `hasHeader(name)`: Returns true if the header identified is currently set.
+- [x] `removeHeader(name)`: Removes a header that's queued for implicit sending.
+- [x] `headersSent`: Boolean (read-only). True if headers were sent, false otherwise.
+- [x] `socket`: Reference to the underlying socket.
+- [x] `Event: 'finish'`: Emitted when the (full) response has been sent.
 
 ### Stream
 

--- a/README.md
+++ b/README.md
@@ -241,20 +241,21 @@ Body Mixins
 
 > http.Server is a class extending `EventEmitter` and implements `@@asyncIterator`.
 
-- [ ] `listen(port, host?)` - Starts the HTTP server listening for connections.
-- [ ] `close()` - Stops the server from accepting new connections.
-- [ ] `Event: 'request'` - Emitted each time there is a request.
-- [ ] `Event: 'close'` - Emitted when the server closes.
-- [ ] `Event: 'clientError'` - Emitted when a client connection emits an 'error' event.
+- [x] `listen(port, host?)`: Starts the HTTP server listening for connections.
+- [x] `close()`: Stops the server from accepting new connections.
+- [x] `accept()`: Waits for a client to connect and accepts the HTTP request.
+- [x] `Event: 'request'`: Emitted each time there is a request.
+- [x] `Event: 'close'`: Emitted when the server closes.
+- [x] `Event: 'clientError'`: Emitted when a client connection emits an 'error' event.
 
 #### `http.ServerRequest`
 
 > http.ServerRequest implements `@@asyncIterator`.
 
-- [x] `headers` - The request headers object.
-- [x] `httpVersion` - The HTTP version sent by the client.
-- [x] `method` - The request method as a string.
-- [x] `url` - Request URL string.
+- [x] `headers`: The request headers object.
+- [x] `httpVersion`: The HTTP version sent by the client.
+- [x] `method`: The request method as a string.
+- [x] `url`: Request URL string.
 - [x] `text()`: Produces a UTF-8 string representation of the body.
 - [x] `json()`: Formats the body using JSON parsing.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `process`: An object that provides info about the current dune process.
 - [x] `structuredClone`: Creates a deep clone of a given value.
 - [x] `AbortController` / `AbortSignal`: Allows you to communicate with a request and abort it.
-- [ ] `fetch`: A wrapper around `http.request` (not compatible with WHATWG fetch).
+- [x] `fetch`: A wrapper around `http.request` (not compatible with WHATWG fetch).
 
 ### Module Metadata
 
@@ -268,7 +268,7 @@ Body Mixins
 - [x] `writeHead(code, message?, headers?)`: Sends the response headers to the client.
 - [x] `setHeader(name, value)`: Sets a single header value for implicit headers.
 - [x] `getHeader(name)`: Reads out a header that's already been queued but not sent to the client.
-- [ ] `getHeaderNames()`: Returns an array containing the unique names of the current outgoing headers.
+- [x] `getHeaderNames()`: Returns an array containing the unique names of the current outgoing headers.
 - [x] `getHeaders()`: Returns a copy of the current outgoing headers.
 - [x] `hasHeader(name)`: Returns true if the header identified is currently set.
 - [x] `removeHeader(name)`: Removes a header that's queued for implicit sending.

--- a/examples/httpServer.js
+++ b/examples/httpServer.js
@@ -1,0 +1,11 @@
+import http from 'http';
+
+const server = http.createServer(async (req, res) => {
+  await res.writeHead(200, { 'Content-Type': 'text/html' });
+  await res.write(req.url);
+  await res.end();
+});
+
+await server.listen(3000);
+
+console.log('Server listening on port 3000...');

--- a/examples/tcpEchoServer.js
+++ b/examples/tcpEchoServer.js
@@ -6,6 +6,6 @@ const server = net.createServer(async (socket) => {
   }
 });
 
-console.log('Server is listening on port 3000...');
-
 await server.listen(3000, '127.0.0.1');
+
+console.log('Server is listening on port 3000...');

--- a/examples/tcpStream.js
+++ b/examples/tcpStream.js
@@ -9,6 +9,6 @@ const server = net.createServer((socket) => {
   pipeline(socket, writer);
 });
 
-console.log('Server listening on port 3000...');
-
 await server.listen(3000, '127.0.0.1');
+
+console.log('Server listening on port 3000...');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dune",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "A hobby runtime for JavaScript and TypeScript 🚀",
   "main": "src/js/main.js",
   "scripts": {

--- a/src/http_parser.rs
+++ b/src/http_parser.rs
@@ -72,8 +72,8 @@ fn parse_incoming_request(
         });
 
     // Get the position the HTTP body starts.
-    let body_at = status.unwrap();
-    let body_at = v8::Integer::new(scope, body_at as i32);
+    let marker = status.unwrap();
+    let marker = v8::Integer::new(scope, marker as i32);
 
     // Build the v8 result object.
     let target = v8::Object::new(scope);
@@ -82,7 +82,7 @@ fn parse_incoming_request(
     set_constant_to(scope, target, "path", path.into());
     set_constant_to(scope, target, "version", version.into());
     set_constant_to(scope, target, "headers", headers.into());
-    set_constant_to(scope, target, "bodyAt", body_at.into());
+    set_constant_to(scope, target, "marker", marker.into());
 
     rv.set(target.into());
 }
@@ -137,15 +137,15 @@ fn parse_incoming_response(
         });
 
     // Get the position the HTTP body starts.
-    let body_at = status.unwrap();
-    let body_at = v8::Integer::new(scope, body_at as i32);
+    let marker = status.unwrap();
+    let marker = v8::Integer::new(scope, marker as i32);
 
     // Build the v8 result object.
     let target = v8::Object::new(scope);
 
     set_constant_to(scope, target, "statusCode", status_code.into());
     set_constant_to(scope, target, "headers", headers.into());
-    set_constant_to(scope, target, "bodyAt", body_at.into());
+    set_constant_to(scope, target, "marker", marker.into());
 
     rv.set(target.into());
 }

--- a/src/http_parser.rs
+++ b/src/http_parser.rs
@@ -16,7 +16,7 @@ pub fn initialize(scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
     v8::Global::new(scope, target)
 }
 
-/// Parses an HTTP request received from a a client.
+/// Parses an HTTP request received from a client.
 fn parse_incoming_request(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
@@ -51,7 +51,7 @@ fn parse_incoming_request(
     let method = request.method.unwrap_or_default().to_ascii_uppercase();
     let method = v8::String::new(scope, &method).unwrap();
 
-    let path = request.path.unwrap_or_default();
+    let path = request.path.unwrap_or("/");
     let path = v8::String::new(scope, &path).unwrap();
 
     let version = request.version.unwrap_or_default();

--- a/src/http_parser.rs
+++ b/src/http_parser.rs
@@ -1,8 +1,7 @@
 use crate::bindings::set_constant_to;
 use crate::bindings::set_function_to;
-use anyhow::Error;
+use anyhow::bail;
 use anyhow::Result;
-use httparse::Status;
 
 pub fn initialize(scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
     // Create local JS object.
@@ -52,7 +51,7 @@ fn parse_incoming_request(
     let method = v8::String::new(scope, &method).unwrap();
 
     let path = request.path.unwrap_or("/");
-    let path = v8::String::new(scope, &path).unwrap();
+    let path = v8::String::new(scope, path).unwrap();
 
     let version = request.version.unwrap_or_default();
     let version = v8::Integer::new(scope, version as i32);
@@ -157,10 +156,10 @@ fn parse_body_chunks(
     mut rv: v8::ReturnValue,
 ) {
     // Get the (current) HTTP body as ArrayBuffer.
-    let response_body: v8::Local<v8::ArrayBufferView> = args.get(0).try_into().unwrap();
+    let buffer: v8::Local<v8::ArrayBufferView> = args.get(0).try_into().unwrap();
 
-    let mut data = vec![0; response_body.byte_length()];
-    response_body.copy_contents(&mut data);
+    let mut data = vec![0; buffer.byte_length()];
+    buffer.copy_contents(&mut data);
 
     // Get all available chunks.
     let (chunks, position, received_last_chunk) = match get_available_chunks(&mut data) {
@@ -172,6 +171,12 @@ fn parse_body_chunks(
             return;
         }
     };
+
+    // Provided bytes are incomplete for processing.
+    if position == 0 {
+        rv.set(v8::null(scope).into());
+        return;
+    }
 
     // Create a v8 typed-array for each chunk.
     let chunks: Vec<v8::Local<v8::Value>> = chunks
@@ -197,39 +202,174 @@ fn parse_body_chunks(
     rv.set(target.into());
 }
 
-const CRLF_LENGTH: usize = 2;
+type RawChunk = Vec<u8>;
 
 /// Extracts available chunks from a buffer.
 fn get_available_chunks(buffer: &mut Vec<u8>) -> Result<(Vec<Vec<u8>>, usize, bool)> {
-    let mut chunks = vec![];
+    // Initialize chunk parser.
+    let mut parser = ChunkParser::new();
+
+    let mut chunks: Vec<RawChunk> = Vec::new();
     let mut cursor_position = 0;
     let mut received_last_chunk = false;
 
     // Loop over the buffer until all available chunks have been extracted.
     loop {
         // Parse the buffer as a chunk size and exit the loop if incomplete.
-        let status = httparse::parse_chunk_size(buffer).map_err(|e| Error::msg(e.to_string()))?;
-        let status = match status {
-            Status::Complete(status) if buffer.len() >= status.1 as usize => status,
-            _ => break,
+        let remaining = match parser.block_parse(buffer) {
+            (done, _) if !done => break,
+            (_done, remaining) => remaining,
         };
 
-        let (chunk_start, chunk_length) = status;
-        let chunk_end = chunk_start + chunk_length as usize;
+        let chunk = match parser.finish() {
+            Some(chunk) => chunk,
+            None => bail!("Couldn't process HTTP chunk."),
+        };
+
+        // Calculate how many bytes when consumed for the chunk.
+        let consumed = buffer.len() - remaining;
+
+        cursor_position += consumed;
 
         // If this is the last chunk, set a flag and exit the loop.
-        if chunk_length == 0 {
-            cursor_position += chunk_end + CRLF_LENGTH;
+        if chunk.size == 0 {
             received_last_chunk = true;
+            parser.clear();
+            buffer.drain(..consumed);
             break;
         }
 
-        // Extract the chunk as a byte vector and update the cursor position.
-        let chunk = buffer[chunk_start..chunk_end].to_vec();
-        cursor_position += chunk_end + CRLF_LENGTH;
-        buffer.drain(0..(chunk_end + CRLF_LENGTH));
-        chunks.push(chunk);
+        // Append current chunk to chunks vector.
+        chunks.push(chunk.body.clone());
+
+        buffer.drain(..consumed);
+        parser.clear();
     }
 
     Ok((chunks, cursor_position, received_last_chunk))
+}
+
+/* --------------------------------------------------------------------------------------*/
+// The following code is copied from the `streaming_httparse` crate.                      /
+// A fast and simple to use HTTP-Parsing crate (https://crates.io/crates/stream-httparse) /
+/* --------------------------------------------------------------------------------------*/
+
+/// A single HTTP-Chunk used for sending data with `Transfer-Encoding: Chunked`.
+#[derive(Debug, PartialEq)]
+pub struct Chunk {
+    pub size: usize,
+    pub body: Vec<u8>,
+}
+
+impl Chunk {
+    /// Creates a new chunk with the given data as its state.
+    pub fn new(size: usize, data: Vec<u8>) -> Self {
+        Self { size, body: data }
+    }
+}
+
+enum ParseState {
+    Size,
+    Content(usize),
+}
+
+/// A single ChunkParser instance used to parse multiple chunks one after the other.
+struct ChunkParser {
+    state: ParseState,
+    head: Vec<u8>,
+    body: Vec<u8>,
+}
+
+const MAX_CHUNK_SIZE: usize = 64 * 2usize.pow(20); // 64 MiB.
+
+impl ChunkParser {
+    /// Creates a new empty instance of the ChunkParser that is ready to start parsing.
+    pub fn new() -> ChunkParser {
+        Self {
+            state: ParseState::Size,
+            head: Vec::with_capacity(16),
+            body: Vec::new(),
+        }
+    }
+
+    /// Clears and resets the internal state.
+    pub fn clear(&mut self) {
+        // Clear the internal buffer
+        self.head.clear();
+        self.body.clear();
+        // Reset the internal state
+        self.state = ParseState::Size;
+    }
+
+    /// Parses and handles each individual byte.
+    fn parse_size(&mut self) -> Option<usize> {
+        match self.head.last() {
+            Some(byte) if *byte != b'\n' => return None,
+            None => return None,
+            _ => {}
+        };
+        self.head.pop();
+        self.head.pop();
+        let head_str = match std::str::from_utf8(&self.head) {
+            Ok(t) => t,
+            Err(_) => {
+                return None;
+            }
+        };
+        let result = match usize::from_str_radix(head_str, 16) {
+            Ok(n) => n,
+            Err(_) => {
+                return None;
+            }
+        };
+        // Safety check to prevent large chunk sizes from allocating too much memory.
+        if result > MAX_CHUNK_SIZE {
+            return None;
+        }
+        Some(result)
+    }
+
+    /// Parses the given block of data, returns the size it parsed as well
+    /// as if it is done with parsing.
+    ///
+    /// Returns:
+    /// * If it is done and the `finish` function should be called.
+    /// * The amount of data that is still left in the Buffer (at the end).
+    pub fn block_parse(&mut self, data: &[u8]) -> (bool, usize) {
+        match self.state {
+            ParseState::Size => {
+                for (index, tmp) in data.iter().enumerate() {
+                    self.head.push(*tmp);
+                    if let Some(n_size) = self.parse_size() {
+                        let n_state = ParseState::Content(n_size);
+                        self.state = n_state;
+                        self.body.reserve(n_size);
+                        return self.block_parse(&data[index + 1..]);
+                    }
+                }
+                (false, 0)
+            }
+            ParseState::Content(size) => {
+                let body_length = self.body.len();
+                let left_to_read = size - body_length;
+                let data_length = data.len();
+                let read_size = std::cmp::min(left_to_read, data_length);
+                self.body.extend_from_slice(&data[..read_size]);
+                (
+                    self.body.len() >= size,
+                    data_length.saturating_sub(read_size + 2),
+                )
+            }
+        }
+    }
+
+    /// Finishes the parsing and returns the finished chunk.
+    pub fn finish(&mut self) -> Option<Chunk> {
+        let size = match self.state {
+            ParseState::Size => return None,
+            ParseState::Content(s) => s,
+        };
+        let body = std::mem::take(&mut self.body);
+        Some(Chunk::new(size, body))
+    }
 }

--- a/src/js/fetch.js
+++ b/src/js/fetch.js
@@ -7,7 +7,7 @@
 
 import http from 'http';
 
-// Utility function that combibes uint8arrays.
+// Utility function that combines uint8arrays.
 function concatUint8Arrays(...arrays) {
   return arrays.reduce(
     (acc, array) => new Uint8Array([...acc, ...array]),

--- a/src/js/fetch.js
+++ b/src/js/fetch.js
@@ -70,6 +70,7 @@ class Response {
       const chunk = new Uint8Array(data);
       chunks.push(chunk);
     }
+    this.#bodyUsed = true;
     const content = concatUint8Arrays(...chunks);
     return content.buffer;
   }

--- a/src/js/fetch.js
+++ b/src/js/fetch.js
@@ -1,0 +1,134 @@
+// Fetch API
+//
+// The global fetch() method starts the process of fetching a resource from the network,
+// returning a promise which is fulfilled once the response is available.
+//
+// https://developer.mozilla.org/en-US/docs/Web/API/fetch
+
+import http from 'http';
+
+// Utility function that combibes uint8arrays.
+function concatUint8Arrays(...arrays) {
+  return arrays.reduce(
+    (acc, array) => new Uint8Array([...acc, ...array]),
+    new Uint8Array(0)
+  );
+}
+
+/**
+ * The Response interface of the Fetch API represents the response to a request.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Response
+ */
+class Response {
+  #statusCode;
+  #headers;
+  #body;
+  #bodyUsed;
+
+  /**
+   * Creates a new Response object.
+   *
+   * @returns {Response}
+   */
+  constructor({ statusCode, headers, body }) {
+    this.#statusCode = statusCode;
+    this.#headers = headers;
+    this.#body = body;
+    this.#bodyUsed = false;
+  }
+
+  /**
+   * Resolves with a text representation of the response body.
+   *
+   * @returns Promise<String>
+   */
+  async text() {
+    const content = await this.#body.text();
+    this.#bodyUsed = true;
+    return content;
+  }
+
+  /**
+   * Resolves with the result of parsing the response body text as JSON.
+   *
+   * @returns Promise<Object>
+   */
+  async json() {
+    const content = await this.#body.json();
+    this.#bodyUsed = true;
+    return content;
+  }
+
+  /**
+   * Resolves with an ArrayBuffer representation of the response body.
+   *
+   * @returns Promise<ArrayBuffer>
+   */
+  async arrayBuffer() {
+    const chunks = [];
+    for await (const data of this.#body) {
+      const chunk = new Uint8Array(data);
+      chunks.push(chunk);
+    }
+    const content = concatUint8Arrays(...chunks);
+    return content.buffer;
+  }
+
+  /**
+   * A ReadableStream of the body contents.
+   */
+  get body() {
+    return this.#body;
+  }
+
+  /**
+   * Stores a boolean value that declares whether the body has been used in a response yet.
+   */
+  get bodyUsed() {
+    return this.#bodyUsed;
+  }
+
+  /**
+   * The Headers object associated with the response.
+   */
+  get headers() {
+    return this.#headers;
+  }
+
+  /**
+   * A boolean indicating whether the response was successful.
+   */
+  get ok() {
+    // Should be in the range (200 – 299).
+    return this.#statusCode >= 200 && this.#statusCode <= 299;
+  }
+
+  /**
+   * The status code of the response. (This will be 200 for a success).
+   */
+  get status() {
+    return this.#statusCode;
+  }
+
+  /**
+   * The status message corresponding to the status code. (e.g., OK for 200).
+   */
+  get statusText() {
+    return http.STATUS_CODES[this.#statusCode];
+  }
+}
+
+/**
+ * Starts the process of fetching a resource from the network.
+ *
+ * @param {String} url
+ * @param {Object} options
+ *
+ * @returns Promise<Response>
+ */
+async function fetch(url, options = {}) {
+  // Fetch is a wrapper around `http.request`.
+  return new Response(await http.request(url, options));
+}
+
+export default fetch;

--- a/src/js/http.js
+++ b/src/js/http.js
@@ -210,8 +210,9 @@ class HttpRequest {
 
     this.#headers = new Map();
     this.#headers.set('host', this.#hostname + ':' + this.#port);
-    this.#headers.set('user-agent', 'Dune HTTP client');
-    this.#headers.set('connection', 'keep-alive');
+    this.#headers.set('user-agent', `dune/${process.version}`);
+    this.#headers.set('accept', '*/*');
+    this.#headers.set('connection', 'close');
     this.#headers.set('content-length', this.#bodyLength);
 
     // Check if encoding should be chunked.

--- a/src/js/http.js
+++ b/src/js/http.js
@@ -280,7 +280,7 @@ class HttpRequest {
     for await (const data of this.#socket) {
       chunks.push(data);
       const buffer = concatUint8Arrays(...chunks);
-      const response = binding.parseHttpResponse(buffer);
+      const response = binding.parseResponse(buffer);
 
       // Response headers are still incomplete.
       if (!response) continue;
@@ -369,7 +369,7 @@ class HttpResponseBody {
   #parseAvailableChunks(data) {
     // Mix current body with new data.
     const buffer = concatUint8Arrays(this.#body, data);
-    const { chunks, position, done } = binding.parseHttpChunks(buffer);
+    const { chunks, position, done } = binding.parseChunks(buffer);
 
     // Update body based on parser's cursor.
     this.#body = buffer.subarray(position);

--- a/src/js/http.js
+++ b/src/js/http.js
@@ -189,9 +189,6 @@ async function* wrapIterable(iterable) {
   }
 }
 
-const encoder = new TextEncoder('utf-8');
-const decoder = new TextDecoder('utf-8');
-
 const urlRegex = new RegExp('^(.*:)//([A-Za-z0-9-.]+)(:[0-9]+)?(.*)$');
 
 /**
@@ -268,6 +265,7 @@ class Request {
 
   async send() {
     // Start building the HTTP message.
+    const encoder = new TextEncoder();
     const reqHeaders = [`${this.#method} ${this.#path} HTTP/1.1`];
 
     // Format and append HTTP headers to message.
@@ -391,6 +389,7 @@ class Body {
    */
   async text() {
     const string = [];
+    const decoder = new TextDecoder();
     const asyncIterator = this[Symbol.asyncIterator]();
     for await (const chunk of asyncIterator) {
       string.push(decoder.decode(chunk));
@@ -794,6 +793,7 @@ class ServerResponse extends EventEmitter {
    */
   async #sendHeaders() {
     // Start building the HTTP message.
+    const encoder = new TextEncoder();
     const resHeaders = [
       `HTTP/1.${this.#version} ${this.#code} ${this.#message}`,
     ];

--- a/src/js/http.js
+++ b/src/js/http.js
@@ -605,7 +605,7 @@ export class ServerRequest {
   constructor(metadata, buffer, socket) {
     this.httpVersion = `1.${metadata.version}`;
     this.method = metadata.method;
-    this.url = metadata.url || '/';
+    this.url = metadata.path;
     this.headers = metadata.headers;
     this.#body = new Body(metadata, buffer, socket);
   }
@@ -834,6 +834,15 @@ class ServerResponse extends EventEmitter {
     }
 
     return this.#headers.get(name.toLowerCase());
+  }
+
+  /**
+   * Returns an array containing the unique names of the current outgoing headers.
+   *
+   * @returns Array<String>
+   */
+  getHeaderNames() {
+    return Array.from(this.#headers.keys());
   }
 
   /**

--- a/src/js/http.js
+++ b/src/js/http.js
@@ -339,7 +339,7 @@ class IncomingResponse {
   constructor(metadata, buffer, socket) {
     this.#statusCode = metadata.statusCode;
     this.#headers = metadata.headers;
-    this.#body = new Body(metadata, this.#headers, buffer, socket, false);
+    this.#body = new Body(metadata, buffer, socket, false);
   }
 
   get statusCode() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,4 +1,5 @@
 import timers from 'timers';
+import fetch from '@web/fetch';
 import structuredClone from '@web/clone';
 import { Console, prompt } from 'console';
 import { cloneFunction, parseEnvVariable } from 'util';
@@ -97,6 +98,7 @@ makeGlobal('TextDecoder', TextDecoder);
 makeGlobal('structuredClone', structuredClone);
 makeGlobal('AbortController', AbortController);
 makeGlobal('AbortSignal', AbortSignal);
+makeGlobal('fetch', fetch);
 
 /* Loading env variables from .env file automatically. */
 

--- a/src/js/net.js
+++ b/src/js/net.js
@@ -134,7 +134,7 @@ export function createServer(onConnection) {
   const server = new Server();
   if (onConnection) {
     assert.isFunction(onConnection);
-    server.onConnection = onConnection;
+    server.on('connection', onConnection);
   }
   return server;
 }
@@ -494,7 +494,6 @@ export class Server extends EventEmitter {
    */
   constructor() {
     super();
-    this.onConnection = undefined;
     this.#pushQueue = [];
     this.#pullQueue = [];
   }
@@ -620,11 +619,7 @@ export class Server extends EventEmitter {
     socket.remoteAddress = remoteAddress;
     socket.remotePort = remotePort;
 
-    if (this.onConnection) {
-      this.onConnection(socket);
-      return;
-    }
-
+    // Check if a connection handler is specified.
     if (this.listenerCount('connection') > 0) {
       this.emit('connection', socket);
       return;

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -44,6 +44,7 @@ lazy_static! {
             ("@web/abort", include_str!("./js/abort-controller.js")),
             ("@web/text_encoding", include_str!("./js/text-encoding.js")),
             ("@web/clone", include_str!("./js/structured-clone.js")),
+            ("@web/fetch", include_str!("./js/fetch.js")),
         ];
         HashMap::from_iter(modules.into_iter())
     };


### PR DESCRIPTION
This PR:
- Implements the classes of `http.Server`, `http.ServerRequest`, `http.ServerResponse`
- Adds support for the global `fetch`
- Fixes numerous issues with HTTP requests
- Fixes issues when parsing chunked HTTP bodies
- Fixes the lifecycle of iterators when used on for-of loops (aligned with the spec)
- Improves HTTP body buffer handling