### PR TITLE
Adding support for `uncaughtException` and `unhandledRejection` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `stdin`: Points to system's `stdin` stream.
 - [x] `stderr`: Points to system's `stderr` stream.
 
+##### Events
+
+- [x] `uncaughtException`: Emitted when an uncaught exception bubbles up to Dune.
+- [x] `unhandledRejection`: Emitted when a Promise is rejected with no handler.
+
+> Signal events will be emitted when the Dune process receives a signal. Please refer to [signal(7)](https://man7.org/linux/man-pages/man7/signal.7.html) for a listing of standard POSIX signal names.
+
 ### File System
 
 > This module also includes a `Sync` method for every async operation available.
@@ -174,10 +181,13 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `accept()`: Waits for a TCP client to connect and accepts the connection.
 - [x] `address()`: Returns the bound address.
 - [x] `close()`: Stops the server from accepting new connections and keeps existing connections.
-- [x] `Event: 'listening'`: Emitted when the server has been bound after calling `server.listen`.
-- [x] `Event: 'connection'`: Emitted when a new connection is made.
-- [x] `Event: 'close'`: Emitted when the server stops accepting new connections.
-- [x] `Event: 'error'`: Emitted when an error occurs.
+
+##### Events
+
+- [x] `listening`: Emitted when the server has been bound after calling `server.listen`.
+- [x] `connection`: Emitted when a new connection is made.
+- [x] `close`: Emitted when the server stops accepting new connections.
+- [x] `error`: Emitted when an error occurs.
 
 #### `net.Socket`
 
@@ -195,12 +205,15 @@ For more examples look at the <a href="./examples">examples</a> directory.
 - [x] `remotePort`: The numeric representation of the remote port.
 - [x] `bytesRead`: The amount of received bytes.
 - [x] `bytesWritten`: The amount of bytes sent.
-- [x] `Event: 'connect'`: Emitted when a socket connection is successfully established.
-- [x] `Event: 'data'`: Emitted when data is received.
-- [x] `Event: 'end'`: Emitted when the other end of the socket sends a FIN packet.
-- [x] `Event: 'error'`: Emitted when an error occurs.
-- [x] `Event: 'close'`: Emitted once the socket is fully closed.
-- [x] `Event: 'timeout'`: Emitted if the socket times out from (read) inactivity.
+
+##### Events
+
+- [x] `connect`: Emitted when a socket connection is successfully established.
+- [x] `data`: Emitted when data is received.
+- [x] `end`: Emitted when the other end of the socket sends a FIN packet.
+- [x] `error`: Emitted when an error occurs.
+- [x] `close`: Emitted once the socket is fully closed.
+- [x] `timeout`: Emitted if the socket times out from (read) inactivity.
 
 ### HTTP
 
@@ -244,9 +257,12 @@ Body Mixins
 - [x] `listen(port, host?)`: Starts the HTTP server listening for connections.
 - [x] `close()`: Stops the server from accepting new connections.
 - [x] `accept()`: Waits for a client to connect and accepts the HTTP request.
-- [x] `Event: 'request'`: Emitted each time there is a request.
-- [x] `Event: 'close'`: Emitted when the server closes.
-- [x] `Event: 'clientError'`: Emitted when a client connection emits an 'error' event.
+
+##### Events
+
+- [x] `request`: Emitted each time there is a request.
+- [x] `close`: Emitted when the server closes.
+- [x] `clientError`: Emitted when a client connection emits an 'error' event.
 
 #### `http.ServerRequest`
 
@@ -274,7 +290,10 @@ Body Mixins
 - [x] `removeHeader(name)`: Removes a header that's queued for implicit sending.
 - [x] `headersSent`: Boolean (read-only). True if headers were sent, false otherwise.
 - [x] `socket`: Reference to the underlying socket.
-- [x] `Event: 'finish'`: Emitted when the (full) response has been sent.
+
+##### Events
+
+- [x] `finish`: Emitted when the (full) response has been sent.
 
 ### Stream
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,6 +1,7 @@
 use crate::dns;
 use crate::errors::extract_error_code;
 use crate::errors::IoError;
+use crate::exceptions;
 use crate::file;
 use crate::http_parser;
 use crate::net;
@@ -30,6 +31,7 @@ lazy_static! {
             ("promise", promise::initialize),
             ("http_parser", http_parser::initialize),
             ("signals", signals::initialize),
+            ("exceptions", exceptions::initialize),
         ];
         HashMap::from_iter(bindings.into_iter())
     };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,6 @@ use crate::compile;
 use crate::dotenv;
 use crate::errors::generic_error;
 use crate::errors::unwrap_or_exit;
-use crate::exceptions::Policy;
 use crate::modules::resolve_import;
 use crate::modules::ImportMap;
 use crate::repl;
@@ -427,12 +426,8 @@ fn test_command(args: &TestArgs) {
 }
 
 fn repl_command() {
-    // Make sure we don't exit on uncaught exceptions.
-    let mut runtime = JsRuntime::new();
-    runtime.set_uncaught_exceptions_policy(Policy::KeepAlive);
-
     // Start REPL.
-    repl::start(runtime);
+    repl::start(JsRuntime::new());
 }
 
 fn upgrade_command() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use crate::compile;
 use crate::dotenv;
 use crate::errors::generic_error;
 use crate::errors::unwrap_or_exit;
+use crate::exceptions::Policy;
 use crate::modules::resolve_import;
 use crate::modules::ImportMap;
 use crate::repl;
@@ -426,8 +427,12 @@ fn test_command(args: &TestArgs) {
 }
 
 fn repl_command() {
+    // Make sure we don't exit on uncaught exceptions.
+    let mut runtime = JsRuntime::new();
+    runtime.set_uncaught_exceptions_policy(Policy::KeepAlive);
+
     // Start REPL.
-    repl::start(JsRuntime::new());
+    repl::start(runtime);
 }
 
 fn upgrade_command() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -180,6 +180,11 @@ pub fn unwrap_or_exit<T>(result: Result<T, Error>) -> T {
     }
 }
 
+pub fn report_and_exit(error: JsError) {
+    eprint!("{error:?}");
+    std::process::exit(1);
+}
+
 /// Returns a string representation of the IO error's code.
 pub fn extract_error_code(err: &IoError) -> Option<&'static str> {
     match err.kind() {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,0 +1,83 @@
+use crate::errors::JsError;
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Policy {
+    Exit,
+    KeepAlive,
+}
+
+pub struct ExceptionState {
+    /// Indicates the report policy.
+    policy: Policy,
+    /// Holds the current uncaught exception.
+    exception: Option<v8::Global<v8::Value>>,
+    /// Holds uncaught promise rejections.
+    promise_rejections: HashMap<v8::Global<v8::Promise>, v8::Global<v8::Value>>,
+}
+
+impl ExceptionState {
+    /// Creates a new store with given report policy.
+    pub fn new_with_policy(policy: Policy) -> Self {
+        ExceptionState {
+            policy,
+            exception: None,
+            promise_rejections: HashMap::new(),
+        }
+    }
+
+    /// Registers the uncaught exception.
+    pub fn emit_exception(&mut self, exception: v8::Global<v8::Value>) {
+        if self.exception.is_none() {
+            self.exception = Some(exception);
+        }
+    }
+
+    /// Registers a promise rejection to the store.
+    pub fn emit_promise_rejection(
+        &mut self,
+        promise: v8::Global<v8::Promise>,
+        reason: v8::Global<v8::Value>,
+    ) {
+        self.promise_rejections.insert(promise, reason);
+    }
+
+    /// Processes all uncaught exceptions and uncaught promise rejections.
+    pub fn report(&mut self, scope: &mut v8::HandleScope<'_>) {
+        // Check for normal uncaught exceptions
+        if let Some(exception) = self.exception.take() {
+            let exception = v8::Local::new(scope, exception);
+            let error = JsError::from_v8_exception(scope, exception, None);
+            eprintln!("{error:?}");
+
+            if self.policy == Policy::Exit {
+                std::process::exit(1);
+            }
+        }
+        // Check for uncaught promise rejections and report them.
+        if let Some((_, rejection)) = self.promise_rejections.drain().next() {
+            let rejection = v8::Local::new(scope, rejection);
+            let error = JsError::from_v8_exception(scope, rejection, Some("(in promise) "));
+            eprintln!("{error:?}");
+
+            if self.policy == Policy::Exit {
+                std::process::exit(1);
+            }
+        }
+    }
+
+    /// Removes a promise rejection from the store.
+    pub fn remove_promise_rejection(&mut self, promise: &v8::Global<v8::Promise>) {
+        self.promise_rejections.remove(promise);
+    }
+
+    /// Returns if we have uncaught promise rejections.
+    pub fn has_promise_rejection(&self) -> bool {
+        !self.promise_rejections.is_empty()
+    }
+
+    /// Sets the reporting policy on uncaught exceptions.
+    pub fn set_report_policy(&mut self, policy: Policy) {
+        self.policy = policy;
+    }
+}

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,51 +1,38 @@
 use crate::bindings::set_function_to;
-use crate::errors::JsError;
 use crate::runtime::JsRuntime;
 use std::collections::HashMap;
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum Policy {
-    Exit,
-    KeepAlive,
-}
-
 pub struct ExceptionState {
-    /// Indicates the report policy.
-    policy: Policy,
     /// Holds the current uncaught exception.
-    exception: Option<v8::Global<v8::Value>>,
+    pub exception: Option<v8::Global<v8::Value>>,
     /// Holds uncaught promise rejections.
-    promise_rejections: HashMap<v8::Global<v8::Promise>, v8::Global<v8::Value>>,
-    /// Pre-hook to run when an uncaught exception is thrown.
-    uncaught_exception_monitor_cb: Option<v8::Global<v8::Function>>,
+    pub promise_rejections: HashMap<v8::Global<v8::Promise>, v8::Global<v8::Value>>,
     /// Hook to run on an uncaught exception.
-    uncaught_exception_cb: Option<v8::Global<v8::Function>>,
+    pub uncaught_exception_cb: Option<v8::Global<v8::Function>>,
     /// Hook to run on an uncaught promise rejection.
-    unhandled_rejection_cb: Option<v8::Global<v8::Function>>,
+    pub unhandled_rejection_cb: Option<v8::Global<v8::Function>>,
 }
 
 impl ExceptionState {
     /// Creates a new store with given report policy.
-    pub fn new_with_policy(policy: Policy) -> Self {
+    pub fn new() -> Self {
         ExceptionState {
-            policy,
             exception: None,
             promise_rejections: HashMap::new(),
-            uncaught_exception_monitor_cb: None,
             uncaught_exception_cb: None,
             unhandled_rejection_cb: None,
         }
     }
 
     /// Registers the uncaught exception.
-    pub fn emit_exception(&mut self, exception: v8::Global<v8::Value>) {
+    pub fn capture_exception(&mut self, exception: v8::Global<v8::Value>) {
         if self.exception.is_none() {
             self.exception = Some(exception);
         }
     }
 
     /// Registers a promise rejection to the store.
-    pub fn emit_promise_rejection(
+    pub fn capture_promise_rejection(
         &mut self,
         promise: v8::Global<v8::Promise>,
         reason: v8::Global<v8::Value>,
@@ -53,87 +40,12 @@ impl ExceptionState {
         self.promise_rejections.insert(promise, reason);
     }
 
-    /// Processes all uncaught exceptions and uncaught promise rejections.
-    pub fn report(&mut self, scope: &mut v8::HandleScope<'_>) {
-        // Check for normal uncaught exceptions
-        if let Some(exception) = self.exception.take() {
-            let exception = v8::Local::new(scope, exception);
-            let error = JsError::from_v8_exception(scope, exception, None);
-
-            self.run_exception_monitor_cb(scope, exception, "uncaughtException");
-            eprintln!("{error:?}");
-
-            match self.policy {
-                Policy::KeepAlive => return,
-                Policy::Exit if self.uncaught_exception_cb.is_some() => return,
-                Policy::Exit => std::process::exit(1),
-            };
-        }
-
-        // Check for uncaught promise rejections and report them.
-        if let Some((_, rejection)) = self.promise_rejections.iter().next() {
-            let rejection = v8::Local::new(scope, rejection);
-            let error = JsError::from_v8_exception(scope, rejection, Some("(in promise) "));
-
-            self.run_exception_monitor_cb(scope, rejection, "unhandledRejection");
-            self.promise_rejections.clear();
-
-            eprintln!("{error:?}");
-
-            match self.policy {
-                Policy::KeepAlive => {}
-                Policy::Exit if self.unhandled_rejection_cb.is_some() => {}
-                Policy::Exit => std::process::exit(1),
-            };
-        }
-    }
-
-    pub fn run_exception_monitor_cb(
-        &self,
-        scope: &mut v8::HandleScope<'_>,
-        exception: v8::Local<'_, v8::Value>,
-        origin: &str,
-    ) {
-        if let Some(callback) = self.uncaught_exception_monitor_cb.as_ref() {
-            let undefined = v8::undefined(scope).into();
-            let callback = v8::Local::new(scope, callback);
-            let origin = v8::String::new(scope, origin).unwrap();
-            let event = v8::String::new(scope, "uncaughtExceptionMonitor").unwrap();
-
-            let tc_scope = &mut v8::TryCatch::new(scope);
-            let params = &[event.into(), exception, origin.into()];
-
-            callback.call(tc_scope, undefined, params);
-
-            // Note: To avoid infinite recursion with these hooks, if this
-            // function throws, exit immediately.
-            if tc_scope.has_caught() {
-                let exception = tc_scope.exception().unwrap();
-                let exception = v8::Local::new(tc_scope, exception);
-                let error = JsError::from_v8_exception(tc_scope, exception, None);
-                eprintln!("{error:?}");
-                std::process::exit(1);
-            }
-        }
-    }
-
-    pub fn remove_promise_rejection(&mut self, promise: &v8::Global<v8::Promise>) {
-        self.promise_rejections.remove(promise);
-    }
-
     pub fn has_promise_rejection(&self) -> bool {
         !self.promise_rejections.is_empty()
     }
 
-    pub fn set_report_policy(&mut self, policy: Policy) {
-        self.policy = policy;
-    }
-
-    pub fn set_uncaught_exception_monitor_callback(
-        &mut self,
-        callback: Option<v8::Global<v8::Function>>,
-    ) {
-        self.uncaught_exception_monitor_cb = callback;
+    pub fn remove_promise_rejection(&mut self, promise: &v8::Global<v8::Promise>) {
+        self.promise_rejections.remove(promise);
     }
 
     pub fn set_uncaught_exception_callback(&mut self, callback: Option<v8::Global<v8::Function>>) {
@@ -152,13 +64,6 @@ pub fn initialize(scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
     set_function_to(
         scope,
         target,
-        "setUncaughtExceptionMonitorCallback",
-        set_uncaught_exception_monitor_callback,
-    );
-
-    set_function_to(
-        scope,
-        target,
         "setUncaughtExceptionCallback",
         set_uncaught_exception_callback,
     );
@@ -172,28 +77,6 @@ pub fn initialize(scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
 
     // Return v8 global handle.
     v8::Global::new(scope, target)
-}
-
-/// Setting the `uncaught_exception_monitor_callback` from JavaScript.
-fn set_uncaught_exception_monitor_callback(
-    scope: &mut v8::HandleScope,
-    args: v8::FunctionCallbackArguments,
-    mut rv: v8::ReturnValue,
-) {
-    // Note: Passing `null` from JavaScript essentially will unset the defined callback.
-    let callback = match v8::Local::<v8::Function>::try_from(args.get(0)) {
-        Ok(callback) => Some(v8::Global::new(scope, callback)),
-        Err(_) => None,
-    };
-
-    let state_rc = JsRuntime::state(scope);
-
-    state_rc
-        .borrow_mut()
-        .exceptions
-        .set_uncaught_exception_monitor_callback(callback);
-
-    rv.set(v8::Boolean::new(scope, true).into());
 }
 
 /// Setting the `uncaught_exception_callback` from JavaScript.

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -48,6 +48,21 @@ impl ExceptionState {
         self.promise_rejections.remove(promise);
     }
 
+    pub fn remove_promise_rejection_entry(&mut self, exception: &v8::Global<v8::Value>) {
+        // Find the correct entry to remove.
+        let mut key_to_remove = None;
+        for (key, value) in self.promise_rejections.iter() {
+            if value == exception {
+                key_to_remove = Some(key.clone());
+                break;
+            }
+        }
+
+        if let Some(promise) = key_to_remove {
+            self.promise_rejections.remove(&promise);
+        }
+    }
+
     pub fn set_uncaught_exception_callback(&mut self, callback: Option<v8::Global<v8::Function>>) {
         self.uncaught_exception_cb = callback;
     }

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,4 +1,6 @@
+use crate::bindings::set_function_to;
 use crate::errors::JsError;
+use crate::runtime::JsRuntime;
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -14,6 +16,12 @@ pub struct ExceptionState {
     exception: Option<v8::Global<v8::Value>>,
     /// Holds uncaught promise rejections.
     promise_rejections: HashMap<v8::Global<v8::Promise>, v8::Global<v8::Value>>,
+    /// Pre-hook to run when an uncaught exception is thrown.
+    uncaught_exception_monitor_cb: Option<v8::Global<v8::Function>>,
+    /// Hook to run on an uncaught exception.
+    uncaught_exception_cb: Option<v8::Global<v8::Function>>,
+    /// Hook to run on an uncaught promise rejection.
+    unhandled_rejection_cb: Option<v8::Global<v8::Function>>,
 }
 
 impl ExceptionState {
@@ -23,6 +31,9 @@ impl ExceptionState {
             policy,
             exception: None,
             promise_rejections: HashMap::new(),
+            uncaught_exception_monitor_cb: None,
+            uncaught_exception_cb: None,
+            unhandled_rejection_cb: None,
         }
     }
 
@@ -48,36 +59,167 @@ impl ExceptionState {
         if let Some(exception) = self.exception.take() {
             let exception = v8::Local::new(scope, exception);
             let error = JsError::from_v8_exception(scope, exception, None);
+
+            self.run_exception_monitor_cb(scope, exception, "uncaughtException");
             eprintln!("{error:?}");
 
-            if self.policy == Policy::Exit {
-                std::process::exit(1);
-            }
+            match self.policy {
+                Policy::KeepAlive => return,
+                Policy::Exit if self.uncaught_exception_cb.is_some() => return,
+                Policy::Exit => std::process::exit(1),
+            };
         }
+
         // Check for uncaught promise rejections and report them.
-        if let Some((_, rejection)) = self.promise_rejections.drain().next() {
+        if let Some((_, rejection)) = self.promise_rejections.iter().next() {
             let rejection = v8::Local::new(scope, rejection);
             let error = JsError::from_v8_exception(scope, rejection, Some("(in promise) "));
+
+            self.run_exception_monitor_cb(scope, rejection, "unhandledRejection");
+            self.promise_rejections.clear();
+
             eprintln!("{error:?}");
 
-            if self.policy == Policy::Exit {
+            match self.policy {
+                Policy::KeepAlive => {}
+                Policy::Exit if self.unhandled_rejection_cb.is_some() => {}
+                Policy::Exit => std::process::exit(1),
+            };
+        }
+    }
+
+    pub fn run_exception_monitor_cb(
+        &self,
+        scope: &mut v8::HandleScope<'_>,
+        exception: v8::Local<'_, v8::Value>,
+        origin: &str,
+    ) {
+        if let Some(callback) = self.uncaught_exception_monitor_cb.as_ref() {
+            let undefined = v8::undefined(scope).into();
+            let callback = v8::Local::new(scope, callback);
+            let origin = v8::String::new(scope, origin).unwrap();
+
+            let tc_scope = &mut v8::TryCatch::new(scope);
+            callback.call(tc_scope, undefined, &[exception, origin.into()]);
+
+            // Note: To avoid infinite recursion with these hooks, if this
+            // function throws, exit immediately.
+            if tc_scope.has_caught() {
+                let exception = tc_scope.exception().unwrap();
+                let exception = v8::Local::new(tc_scope, exception);
+                let error = JsError::from_v8_exception(tc_scope, exception, None);
+                eprintln!("{error:?}");
                 std::process::exit(1);
             }
         }
     }
 
-    /// Removes a promise rejection from the store.
     pub fn remove_promise_rejection(&mut self, promise: &v8::Global<v8::Promise>) {
         self.promise_rejections.remove(promise);
     }
 
-    /// Returns if we have uncaught promise rejections.
     pub fn has_promise_rejection(&self) -> bool {
         !self.promise_rejections.is_empty()
     }
 
-    /// Sets the reporting policy on uncaught exceptions.
     pub fn set_report_policy(&mut self, policy: Policy) {
         self.policy = policy;
     }
+
+    pub fn set_uncaught_exception_monitor_callback(&mut self, callback: v8::Global<v8::Function>) {
+        self.uncaught_exception_monitor_cb = Some(callback);
+    }
+
+    pub fn set_uncaught_exception_callback(&mut self, callback: v8::Global<v8::Function>) {
+        self.uncaught_exception_cb = Some(callback);
+    }
+
+    pub fn set_unhandled_rejection_callback(&mut self, callback: v8::Global<v8::Function>) {
+        self.unhandled_rejection_cb = Some(callback);
+    }
+}
+
+pub fn initialize(scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
+    // Create local JS object.
+    let target = v8::Object::new(scope);
+
+    set_function_to(
+        scope,
+        target,
+        "setUncaughtExceptionMonitorCallback",
+        set_uncaught_exception_monitor_callback,
+    );
+
+    set_function_to(
+        scope,
+        target,
+        "setUncaughtExceptionCallback",
+        set_uncaught_exception_callback,
+    );
+
+    set_function_to(
+        scope,
+        target,
+        "setUnhandledRejectionCallback",
+        set_unhandled_rejection_callback,
+    );
+
+    // Return v8 global handle.
+    v8::Global::new(scope, target)
+}
+
+/// Setting the `uncaught_exception_monitor_callback` from JavaScript.
+fn set_uncaught_exception_monitor_callback(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue,
+) {
+    // Get the callback from JavaScript.
+    let callback = v8::Local::<v8::Function>::try_from(args.get(0)).unwrap();
+    let callback = v8::Global::new(scope, callback);
+
+    let state_rc = JsRuntime::state(scope);
+
+    state_rc
+        .borrow_mut()
+        .exceptions
+        .set_uncaught_exception_monitor_callback(callback);
+
+    rv.set(v8::Boolean::new(scope, true).into());
+}
+
+/// Setting the `uncaught_exception_callback` from JavaScript.
+fn set_uncaught_exception_callback(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue,
+) {
+    // Get the callback from JavaScript.
+    let callback = v8::Local::<v8::Function>::try_from(args.get(0)).unwrap();
+    let callback = v8::Global::new(scope, callback);
+
+    let state_rc = JsRuntime::state(scope);
+    let mut state = state_rc.borrow_mut();
+
+    state.exceptions.set_uncaught_exception_callback(callback);
+
+    rv.set(v8::Boolean::new(scope, true).into());
+}
+
+/// Setting the `unhandled_rejection_callback` from JavaScript.
+fn set_unhandled_rejection_callback(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut rv: v8::ReturnValue,
+) {
+    // Get the callback from JavaScript.
+    let callback = v8::Local::<v8::Function>::try_from(args.get(0)).unwrap();
+    let callback = v8::Global::new(scope, callback);
+
+    let state_rc = JsRuntime::state(scope);
+    let mut state = state_rc.borrow_mut();
+
+    state.exceptions.set_unhandled_rejection_callback(callback);
+
+    rv.set(v8::Boolean::new(scope, true).into());
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -127,11 +127,11 @@ pub extern "C" fn promise_reject_cb(message: v8::PromiseRejectMessage) {
 
     match event {
         PromiseHandlerAddedAfterReject => {
-            state.promise_exceptions.remove(&promise);
+            state.exceptions.remove_promise_rejection(&promise);
         }
         PromiseRejectWithNoHandler => {
             let reason = v8::Global::new(scope, reason);
-            state.promise_exceptions.insert(promise, reason);
+            state.exceptions.emit_promise_rejection(promise, reason);
         }
         PromiseRejectAfterResolved | PromiseResolveAfterResolved => {}
     }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -133,7 +133,7 @@ pub extern "C" fn promise_reject_cb(message: v8::PromiseRejectMessage) {
         }
         PromiseRejectWithNoHandler => {
             let reason = v8::Global::new(scope, reason);
-            state.exceptions.emit_promise_rejection(promise, reason);
+            state.exceptions.capture_promise_rejection(promise, reason);
         }
         PromiseRejectAfterResolved | PromiseResolveAfterResolved => {}
     }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -53,6 +53,8 @@ pub extern "C" fn host_initialize_import_meta_object_cb(
 ) {
     // Get `CallbackScope` from context.
     let scope = &mut unsafe { v8::CallbackScope::new(context) };
+    let scope = &mut v8::HandleScope::new(scope);
+
     let state = JsRuntime::state(scope);
     let state = state.borrow();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod dns;
 mod dotenv;
 mod errors;
+mod exceptions;
 mod file;
 mod hooks;
 mod http_parser;

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,7 +1,6 @@
 use crate::bindings::set_exception_code;
 use crate::bindings::set_function_to;
 use crate::bindings::set_property_to;
-use crate::errors::JsError;
 use crate::runtime::JsFuture;
 use crate::runtime::JsRuntime;
 use anyhow::Result;
@@ -324,9 +323,9 @@ impl JsFuture for TcpListenFuture {
 
         if tc_scope.has_caught() {
             let exception = tc_scope.exception().unwrap();
-            let exception = JsError::from_v8_exception(tc_scope, exception, None);
-            println!("{exception:?}");
-            std::process::exit(1);
+            let exception = v8::Global::new(tc_scope, exception);
+            let state = JsRuntime::state(tc_scope);
+            state.borrow_mut().exceptions.emit_exception(exception);
         }
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -325,7 +325,7 @@ impl JsFuture for TcpListenFuture {
             let exception = tc_scope.exception().unwrap();
             let exception = v8::Global::new(tc_scope, exception);
             let state = JsRuntime::state(tc_scope);
-            state.borrow_mut().exceptions.emit_exception(exception);
+            state.borrow_mut().exceptions.capture_exception(exception);
         }
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -265,12 +265,9 @@ pub fn start(mut runtime: JsRuntime) {
 
         // Poll the event-loop.
         if maybe_message.is_err() {
-            // Tick the event loop.
+            // Tick the event loop and report exceptions.
             runtime.tick_event_loop();
-            // Report if any unhandled promise rejection has been caught.
-            if runtime.has_promise_rejections() {
-                println!("{}", runtime.promise_rejections().remove(0));
-            }
+            runtime.report_exceptions();
             continue;
         }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,3 +1,4 @@
+use crate::runtime::check_exceptions;
 use crate::runtime::JsRuntime;
 use colored::*;
 use phf::phf_set;
@@ -267,7 +268,11 @@ pub fn start(mut runtime: JsRuntime) {
         if maybe_message.is_err() {
             // Tick the event loop and report exceptions.
             runtime.tick_event_loop();
-            runtime.report_exceptions();
+            // Check for exceptions.
+            let scope = &mut runtime.handle_scope();
+            if let Some(error) = check_exceptions(scope) {
+                eprintln!("{error}");
+            }
             continue;
         }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -281,7 +281,7 @@ pub fn start(mut runtime: JsRuntime) {
             ReplMessage::Evaluate(expression) => {
                 match runtime.execute_script("<anonymous>", &expression) {
                     // Format the expression using console.log.
-                    Ok(value) => {
+                    Ok(Some(value)) => {
                         let scope = &mut runtime.handle_scope();
                         let context = v8::Local::new(scope, context.clone());
                         let scope = &mut v8::ContextScope::new(scope, context);
@@ -295,6 +295,7 @@ pub fn start(mut runtime: JsRuntime) {
                         let value = v8::Local::new(scope, value);
                         log.call(scope, global.into(), &[value]);
                     }
+                    Ok(None) => {}
                     Err(e) => eprintln!("{e}"),
                 };
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -505,9 +505,12 @@ impl JsRuntime {
             let _ = module.evaluate(tc_scope);
 
             if module.get_status() == v8::ModuleStatus::Errored {
+                let mut state = state_rc.borrow_mut();
                 let exception = module.get_exception();
-                let exception = JsError::from_v8_exception(tc_scope, exception, None);
-                eprintln!("{exception:?}");
+                let exception = v8::Global::new(tc_scope, exception);
+
+                state.exceptions.emit_exception(exception);
+                state.exceptions.report(tc_scope);
                 std::process::exit(1);
             }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,4 +1,5 @@
 use crate::bindings;
+use crate::errors::report_and_exit;
 use crate::errors::unwrap_or_exit;
 use crate::errors::JsError;
 use crate::exceptions::ExceptionState;
@@ -237,8 +238,7 @@ impl JsRuntime {
             assert!(tc_scope.has_caught());
             let exception = tc_scope.exception().unwrap();
             let exception = JsError::from_v8_exception(tc_scope, exception, None);
-            eprintln!("{exception:?}");
-            std::process::exit(1);
+            report_and_exit(exception);
         }
 
         let _ = module.evaluate(tc_scope);
@@ -246,8 +246,7 @@ impl JsRuntime {
         if module.get_status() == v8::ModuleStatus::Errored {
             let exception = module.get_exception();
             let exception = JsError::from_v8_exception(tc_scope, exception, None);
-            eprintln!("{exception:?}");
-            std::process::exit(1);
+            report_and_exit(exception);
         }
 
         // Initialize process static values.
@@ -396,8 +395,7 @@ impl JsRuntime {
 
             // Report any unhandled promise rejections.
             if let Some(error) = check_exceptions(&mut self.handle_scope()) {
-                eprintln!("{error:?}");
-                std::process::exit(1);
+                report_and_exit(error);
             }
         }
 
@@ -429,8 +427,7 @@ impl JsRuntime {
         for mut fut in futures {
             fut.run(scope);
             if let Some(error) = check_exceptions(scope) {
-                eprintln!("{error:?}");
-                std::process::exit(1);
+                report_and_exit(error);
             }
             run_next_tick_callbacks(scope);
         }
@@ -509,8 +506,7 @@ impl JsRuntime {
                 assert!(tc_scope.has_caught());
                 let exception = tc_scope.exception().unwrap();
                 let exception = JsError::from_v8_exception(tc_scope, exception, None);
-                eprintln!("{exception:?}");
-                std::process::exit(1);
+                report_and_exit(exception);
             }
 
             let _ = module.evaluate(tc_scope);
@@ -524,8 +520,7 @@ impl JsRuntime {
                 drop(state);
 
                 if let Some(error) = check_exceptions(tc_scope) {
-                    eprintln!("{error:?}");
-                    std::process::exit(1);
+                    report_and_exit(error);
                 }
 
                 // Note: Due to the architecture, when a module errors, the `promise_reject_cb`
@@ -638,8 +633,7 @@ fn run_next_tick_callbacks(scope: &mut v8::HandleScope) {
 
             // Check for uncaught errors (capture callbacks might be in place).
             if let Some(error) = check_exceptions(tc_scope) {
-                eprintln!("{error:?}");
-                std::process::exit(1);
+                report_and_exit(error);
             }
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -527,6 +527,12 @@ impl JsRuntime {
                     eprintln!("{error:?}");
                     std::process::exit(1);
                 }
+
+                // Note: Due to the architecture, when a module errors, the `promise_reject_cb`
+                // v8 hook will also trigger, resulting in the same exception being registered
+                // as an unhandled promise rejection. Therefore, we need to manually clear the
+                // promise_rejections here.
+                state_rc.borrow_mut().exceptions.promise_rejections.clear();
             }
 
             if let ImportKind::Dynamic(main_promise) = graph.kind.clone() {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -259,32 +259,43 @@ impl JsRuntime {
         &mut self,
         filename: &str,
         source: &str,
-    ) -> Result<v8::Global<v8::Value>, Error> {
+    ) -> Result<Option<v8::Global<v8::Value>>, Error> {
         // Get the handle-scope.
         let scope = &mut self.handle_scope();
+        let state_rc = JsRuntime::state(scope);
 
         let origin = create_origin(scope, filename, false);
         let source = v8::String::new(scope, source).unwrap();
 
         // The `TryCatch` scope allows us to catch runtime errors rather than panicking.
         let tc_scope = &mut v8::TryCatch::new(scope);
+        type ExecuteScriptResult = Result<Option<v8::Global<v8::Value>>, Error>;
+
+        let handle_exception =
+            |scope: &mut v8::TryCatch<'_, v8::HandleScope<'_>>| -> ExecuteScriptResult {
+                // Extract the exception during compilation.
+                assert!(scope.has_caught());
+                let exception = scope.exception().unwrap();
+                let exception = v8::Global::new(scope, exception);
+                let mut state = state_rc.borrow_mut();
+                // Capture the exception internally.
+                state.exceptions.capture_exception(exception);
+                drop(state);
+                // Force an exception check.
+                if let Some(error) = check_exceptions(scope) {
+                    bail!(error)
+                }
+                Ok(None)
+            };
 
         let script = match v8::Script::compile(tc_scope, source, Some(&origin)) {
             Some(script) => script,
-            None => {
-                assert!(tc_scope.has_caught());
-                let exception = tc_scope.exception().unwrap();
-                bail!(JsError::from_v8_exception(tc_scope, exception, None));
-            }
+            None => return handle_exception(tc_scope),
         };
 
         match script.run(tc_scope) {
-            Some(value) => Ok(v8::Global::new(tc_scope, value)),
-            None => {
-                assert!(tc_scope.has_caught());
-                let exception = tc_scope.exception().unwrap();
-                bail!(JsError::from_v8_exception(tc_scope, exception, None));
-            }
+            Some(value) => Ok(Some(v8::Global::new(tc_scope, value))),
+            None => handle_exception(tc_scope),
         }
     }
 

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,7 +1,6 @@
 use crate::bindings::set_function_to;
 use crate::bindings::set_property_to;
 use crate::bindings::throw_exception;
-use crate::errors::JsError;
 use crate::runtime::JsFuture;
 use crate::runtime::JsRuntime;
 use anyhow::anyhow;
@@ -86,9 +85,9 @@ impl JsFuture for SignalFuture {
         // On exception, report it and exit.
         if tc_scope.has_caught() {
             let exception = tc_scope.exception().unwrap();
-            let exception = JsError::from_v8_exception(tc_scope, exception, None);
-            println!("{exception:?}");
-            std::process::exit(1);
+            let exception = v8::Global::new(tc_scope, exception);
+            let state = JsRuntime::state(tc_scope);
+            state.borrow_mut().exceptions.emit_exception(exception);
         }
     }
 }

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -87,7 +87,7 @@ impl JsFuture for SignalFuture {
             let exception = tc_scope.exception().unwrap();
             let exception = v8::Global::new(tc_scope, exception);
             let state = JsRuntime::state(tc_scope);
-            state.borrow_mut().exceptions.emit_exception(exception);
+            state.borrow_mut().exceptions.capture_exception(exception);
         }
     }
 }

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -41,7 +41,7 @@ impl JsFuture for TimeoutFuture {
             let exception = tc_scope.exception().unwrap();
             let exception = v8::Global::new(tc_scope, exception);
             let state = JsRuntime::state(tc_scope);
-            state.borrow_mut().exceptions.emit_exception(exception);
+            state.borrow_mut().exceptions.capture_exception(exception);
         }
     }
 }
@@ -142,7 +142,7 @@ impl JsFuture for ImmediateFuture {
             let exception = tc_scope.exception().unwrap();
             let exception = v8::Global::new(tc_scope, exception);
             let state = JsRuntime::state(tc_scope);
-            state.borrow_mut().exceptions.emit_exception(exception);
+            state.borrow_mut().exceptions.capture_exception(exception);
         }
     }
 }


### PR DESCRIPTION
This PR:
- Enables the following events: `uncaughtException` and `unhandledRejection`.
- Updates the `the-runtime.md` documentation file.