### PR TITLE
Removing unnecessary crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,22 +714,18 @@ dependencies = [
  "colored",
  "dirs 5.0.1",
  "dns-lookup",
- "downcast-rs",
  "dune_event_loop",
  "enable-ansi-support",
  "futures",
  "httparse",
  "indicatif",
  "lazy_static",
- "nanoid",
  "nix 0.29.0",
  "notify",
  "path-absolutize",
- "path-clean",
  "pest",
  "pest_derive",
  "phf",
- "rayon",
  "regex",
  "rustyline",
  "rustyline-derive",
@@ -1493,15 +1489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,12 +1674,6 @@ checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
 dependencies = [
  "path-dedot",
 ]
-
-[[package]]
-name = "path-clean"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "path-dedot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,10 @@ v8 = { version = "129.0.0", default-features = false }
 clap = { version = "4.5.20", features = ["derive"] }
 anyhow = "1.0.90"
 colored = "2.1.0"
-path-clean = "1.0.1"
 rustyline = "14.0.0"
 rustyline-derive = "0.10.0"
 lazy_static = "1.5.0"
-rayon = "1.10.0"
 sha = "1.0.3"
-nanoid = "0.4.0"
 regex = "1.11.0"
 dirs = "5.0.1"
 path-absolutize = "3.1.1"
@@ -37,7 +34,6 @@ phf = { version = "0.11.2", features = ["macros"] }
 url = "2.5.2"
 clearscreen = "3.0.0"
 bincode = "1.3.3"
-downcast-rs = { version = "1.2.1", default-features = false }
 swc_common = { version = "2.0.1", features = ["tty-emitter", "sourcemap"] }
 swc_ecma_codegen = "2.0.0"
 swc_ecma_parser = "3.0.1"
@@ -48,6 +44,7 @@ swc_bundler = "3.0.0"
 swc_ecma_ast = "2.0.0"
 swc_ecma_loader = "2.0.0"
 swc_atoms = "2.0.0"
+swc_ecma_transforms = "3.0.0"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.132"
 dns-lookup = "2.0.4"
@@ -62,7 +59,6 @@ tokio = { version = "1.40.0", features = ["full"] }
 axum = { version = "0.7.7", features = ["ws"] }
 uuid = { version = "1.11.0", features = ["v4", "fast-rng"] }
 base64 = "0.22.1"
-swc_ecma_transforms = "3.0.0"
 indicatif = "0.17.8"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This PR:
- Removes some unnecessary crates.
> Some of these are no longer used since we relocated the event-loop logic to its own repository.