### PR TITLE
Bringing back dependabot config for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
+  - package-ecosystem: 'cargo'
+    directory: '/'
+    open-pull-requests-limit: 5
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     ignore:
-      - dependency-name: "swc*"
-      - dependency-name: "v8*"
-      - dependency-name: "sourcemap*"
-      - dependency-name: "bincode*"
-
+      - dependency-name: 'swc*'
+      - dependency-name: 'v8*'
+      - dependency-name: 'sourcemap*'
+      - dependency-name: 'bincode*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "swc*"
+      - dependency-name: "v8*"
+      - dependency-name: "sourcemap*"
+      - dependency-name: "bincode*"
+


### PR DESCRIPTION
This PR:
- Brings back the dependabot, but excludes the following crates:
1. v8
2. swc
3. sourcemaps
4. bincode

> These crates should be updated manually since a lot of times they introduce breaking changes.