### PR TITLE
Adding an ignore list in CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,8 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          paths-ingore:
+            - examples/**
       # Autobuild attempts to build any compiled languages.
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           paths-ingore:
-            - examples/**
+            - examples/**/*.js
       # Autobuild attempts to build any compiled languages.
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4


### PR DESCRIPTION
This PR:
- Ignores every JavaScript file under the `examples/` folder when the CodeQL action runs