### PR TITLE
Setting up ignore list for CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,8 +27,6 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          paths:
-            - src
       # Autobuild attempts to build any compiled languages.
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,10 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          paths:
+            - src
+          paths-ignore:
+            - examples/**
       # Autobuild attempts to build any compiled languages.
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,8 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          paths-ignore:
+            - examples/**/*.js
       # Autobuild attempts to build any compiled languages.
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript']
+        language: ['rust', 'javascript']
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -27,11 +27,12 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          paths-ignore:
-            - 'examples/**'
+          config: |
+            paths-ignore:
+              - 'examples/**'
       # Autobuild attempts to build any compiled languages.
-      # - name: Autobuild
-      # uses: github/codeql-action/autobuild@v4
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
       # Run code analysis
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,8 +27,8 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          paths-ignore:
-            - examples/**/*.js
+          paths:
+            - src
       # Autobuild attempts to build any compiled languages.
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,10 +27,8 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          paths:
-            - src
           paths-ignore:
-            - examples/**
+            - 'examples/**'
       # Autobuild attempts to build any compiled languages.
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['rust', 'javascript']
+        language: ['javascript']
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -30,8 +30,8 @@ jobs:
           paths-ignore:
             - 'examples/**'
       # Autobuild attempts to build any compiled languages.
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+      # - name: Autobuild
+      # uses: github/codeql-action/autobuild@v4
       # Run code analysis
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
This PR:
- Ignores all JavaScript files under the `examples` folder when running the CodeQL action